### PR TITLE
Replace static initializers with managed initializers; add Exit handlers

### DIFF
--- a/examples/test_create_sheet.ts
+++ b/examples/test_create_sheet.ts
@@ -3,8 +3,6 @@ import * as _core from '../lib/core-exec';
 import * as sheets from '../lib/sheets';
 
 _core.main(() => {
-    sheets.initialize();
-
     const sheet = sheets.createSheet("TestSheet");
 
     sheet.appendRow(["asdf", "asdf", "1", "13", "asdf"]);

--- a/examples/test_get_sheet.ts
+++ b/examples/test_get_sheet.ts
@@ -3,8 +3,6 @@ import * as _core from '../lib/core-exec';
 import * as sheets from '../lib/sheets';
 
 _core.main(() => {
-    sheets.initialize();
-
     const sheet = sheets.getSheet("1FcfEth7aMtUG1MbU9h_uEIoaHMS9tQq0zJryIAroZpE");
     // sheet.clear();
 

--- a/lib/core-exec.ts
+++ b/lib/core-exec.ts
@@ -1,5 +1,6 @@
 import Fiber = require('fibers');
 import Future = require('fibers/future');
+import { log } from './console';
 
 export const env = process.env;
 
@@ -9,24 +10,84 @@ export const hacks: {
 	wrtc: undefined,
 }
 
+let executing: boolean = false;
+const initializers: Set<() => void> = new Set();
+const exitHandlers: Set<() => void> = new Set();
+
+/*
+ *  The behavior of the default rejection handler.
+ *
+ *  Log the reason and kill the process.
+ */
+function catchPromiseRejection(reason: any) {
+	log("Unhandled exception from Event Loop:", reason);
+	process.exit(1);
+}
+
 /**
- * On Start
+ * Code to run on start
+ * 
+ * @param body The main thread of the program.
  */
 export function main(body: () => void) {
-	Fiber(body).run();
+	if (!executing) {
+		executing = true;
+		initializers.forEach((init) => init());
+
+		Fiber(body).run();
+	} else {
+		throw new Error("core module attempted to execute twice");
+	}
+}
+
+/**
+ * Add an initializer to the initializer stack. Initializers are run in FIFO
+ * order: the first initializer added to the stack will be the first initializer
+ * that is executed on the start of the program.
+ * 
+ * @param initializer The function to run when the user code is initialized
+ */
+export function onInit(initializer: () => void) {
+	initializers.add(initializer);
+}
+
+/**
+ * Add a routine to the exit stack. Exit handlers are run in FIFO order: the
+ * first cleanup routine added to the stack will be the first cleanup routine
+ * that is executed when the program exits.
+ * 
+ * @param cleanup The function to run when the program terminates.
+ */
+export function onExit(cleanup: () => void) {
+	exitHandlers.add(cleanup);
 }
 
 export function _detach(body: () => void) {
 	(Future as any).task(body).detach();
 }
 
-export function _await<T>(task: Promise<T>): T {
+export function _await<T>(task: Promise<T>, catcher?: (reason: any) => PromiseLike<T>): T {
 	const fiber = Fiber.current;
 	let r: T;
 	task.then((val: T) => {
 		r = val;
 		fiber.run();
-	});
+	}).catch(catcher || catchPromiseRejection);
 	Fiber.yield();
 	return r;
 }
+
+// Set up the exit handlers for the module
+function atexit(reason: string, ...args: any[]) {
+	log("EXIT: " + reason);
+
+	if (reason === 'uncaughtException') {
+		log(args[0].message, args[0].stack);
+	}
+
+	exitHandlers.forEach((h) => h());
+}
+
+process.on('exit', () => atexit('EXIT'));
+process.on('SIGINT', () => atexit('SIGINT'));
+process.on('uncaughtException', (e) => atexit('uncaughtException', e));

--- a/lib/gpio.ts
+++ b/lib/gpio.ts
@@ -1,7 +1,16 @@
 import { Gpio } from 'onoff';
-import { _detach } from './core-exec';
+import { _detach, onExit } from './core-exec';
 
-let allPins: { [k: string]: Gpio };
+const allPins: { [k: string]: Gpio } = {};
+
+
+onExit(() => {
+    Object.keys(allPins).forEach((k) => {
+        if (allPins.hasOwnProperty(k)) {
+            allPins[k].unexport();
+        }
+    });
+});
 
 function lazyPin(pin: Pins): Gpio {
     let p = allPins[pin];
@@ -10,10 +19,6 @@ function lazyPin(pin: Pins): Gpio {
         allPins[pin] = p;
     }
     return p;
-}
-
-export function initialize() {
-    allPins = {};
 }
 
 export enum Direction {

--- a/lib/netsimple.ts
+++ b/lib/netsimple.ts
@@ -2,7 +2,7 @@ import { SignalingClient } from 'dss-client';
 import { URL } from 'url';
 import uuidv4 = require('uuid/v4');
 
-import { _await, _detach, env, hacks } from './core-exec';
+import { _await, _detach, env, hacks, onExit } from './core-exec';
 
 import { log } from './console';
 
@@ -10,12 +10,10 @@ let client: SignalingClient;
 
 const COMM_NAME = 'comms';
 
-const connections: { [k: string] : RTCDataChannel } = {};
+const connections: { [k: string]: RTCDataChannel } = {};
 
-const onConnectEvents: { [k: string] : Array<() => void> } = {}
-
+const onConnectEvents: { [k: string]: Array<() => void> } = {}
 const onMessageEvents: Array<(p: string, m: string) => void> = [];
-
 const onMessageFromEvents: { [k: string]: Array<(m: string) => void> } = {};
 
 let initialized = false;
@@ -40,10 +38,13 @@ function wireConnEvents(channel: RTCDataChannel, otherID: string): void {
     }
 }
 
-// Really just have to mask this function...
-export function initialize() {
-    return;
-}
+onExit(() => {
+    Object.keys(connections).forEach((k) => {
+        if (connections.hasOwnProperty(k)) {
+            connections[k].close();
+        }
+    });
+})
 
 export function start() {
     _join();
@@ -67,11 +68,13 @@ function _join(id?: string) {
             webRTCOptions: {
                 peerOptions: {
                     iceServers: [
-                        {urls: [
-                            'stuns:stun1.l.google.com:19302',
-                            'stuns:stun2.l.google.com:19302',
-                            'stuns:stun3.l.google.com:19302',
-                            'stuns:stun4.l.google.com:19302']
+                        {
+                            urls: [
+                                'stuns:stun1.l.google.com:19302',
+                                'stuns:stun2.l.google.com:19302',
+                                'stuns:stun3.l.google.com:19302',
+                                'stuns:stun4.l.google.com:19302'
+                            ]
                         }
                     ]
                 }
@@ -103,7 +106,7 @@ export function sendString(message: string, peer: string) {
     }
 }
 
-function _registerKeyedHandler(registry: {[k: string] : any}, key: string, handler: any) {
+function _registerKeyedHandler(registry: { [k: string]: any }, key: string, handler: any) {
     let handlers = registry[key];
     if (!handlers) {
         handlers = [];

--- a/lib/sheets.ts
+++ b/lib/sheets.ts
@@ -1,5 +1,5 @@
 import * as fs from "fs";
-import { env } from "./core-exec";
+import { env, onInit } from "./core-exec";
 
 import { google } from 'googleapis';
 import { OAuth2Client } from "googleapis-common";
@@ -18,7 +18,7 @@ let sheets: any;
 const SHEET_NAME = 'Sheet1';
 
 // parse token.js and credentials.js
-export function initialize() {
+onInit(() => {
     const tokenPath = env.GOOGLE_TOKEN_PATH;
     const credPath = env.GOOGLE_CREDENTIAL_PATH;
 
@@ -35,7 +35,7 @@ export function initialize() {
     sheets = google.sheets({ version: 'v4', auth: oAuth2Client });
 
     return;
-}
+});
 
 /** Class representing a google spreadsheet. */
 export class Spreadsheet {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@types/node": {
-      "version": "10.12.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
-      "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==",
+      "version": "10.12.30",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.30.tgz",
+      "integrity": "sha512-nsqTN6zUcm9xtdJiM9OvOJ5EF0kOI8f1Zuug27O/rgtxCRJHGqncSWfCMZUP852dCKPsDsYXGvBhxfRjDBkF5Q==",
       "dev": true
     },
     "@types/node-fibers": {
@@ -22,7 +22,23 @@
       "integrity": "sha512-tPIgT0GUmdJQNSHxp0X2jnpQfBSTfGxUMc/2CXBU2mnyTFVYVa2ojpoQ74w0U2yn2vw3jnC640+77lkFFpdVDw==",
       "dev": true,
       "requires": {
-        "@types/node": "10.12.18"
+        "@types/node": "*"
+      }
+    },
+    "abort-controller": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-2.0.3.tgz",
+      "integrity": "sha512-EPSq5wr2aFyAZ1PejJB32IX9Qd4Nwus+adnp7STYFM5/23nLPBazqZ1oor6ZqbH+4otaaGXTlC8RN5hq3C8w9Q==",
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
+    },
+    "agent-base": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+      "requires": {
+        "es6-promisify": "^5.0.0"
       }
     },
     "ansi": {
@@ -35,8 +51,8 @@
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
       "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
       "requires": {
-        "delegates": "1.0.0",
-        "readable-stream": "2.3.6"
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
       }
     },
     "async": {
@@ -44,20 +60,53 @@
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
     },
+    "base64-js": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
+      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
+    },
+    "bignumber.js": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
+      "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
+    },
     "bindings": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.1.tgz",
       "integrity": "sha512-i47mqjF9UbjxJhxGf+pZ6kSxrnI3wBLlnGI2ArWJ4r0VrvDS7ZYXkprq/pLaBWYq4GM0r4zdHY+NNRqEMU7uew=="
+    },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "buffertools": {
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/buffertools/-/buffertools-2.1.6.tgz",
       "integrity": "sha1-MMGbCFY2uI32kq7v7qD/FWeA6RY="
     },
+    "complex.js": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.0.1.tgz",
+      "integrity": "sha1-6pDHoFrs6vOjdtLA9qeEIXJ9aHk="
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "debug": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+      "requires": {
+        "ms": "^2.1.1"
+      }
+    },
+    "decimal.js": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-7.1.1.tgz",
+      "integrity": "sha1-GtytfXDXqRxCbXVvHrZWbDvmy88="
     },
     "delegates": {
       "version": "1.0.0",
@@ -72,60 +121,55 @@
     "dss-client": {
       "version": "file:../dss/client",
       "requires": {
-        "apollo-cache-inmemory": "1.3.12",
-        "apollo-client": "2.4.8",
-        "apollo-link": "1.2.6",
-        "apollo-link-http": "1.5.9",
-        "apollo-link-ws": "1.0.12",
-        "apollo-utilities": "1.0.27",
-        "cross-fetch": "3.0.0",
-        "dss-common": "0.1.0",
-        "graphql": "14.0.2",
-        "graphql-tag": "2.10.0",
-        "node-fetch": "2.3.0",
-        "subscriptions-transport-ws": "0.9.15",
-        "uuid": "3.3.2",
-        "webrtc-adapter": "7.1.1",
-        "wrtc": "0.3.4"
+        "apollo-cache-inmemory": "^1.3.12",
+        "apollo-client": "^2.4.8",
+        "apollo-link": "^1.2.6",
+        "apollo-link-http": "^1.5.9",
+        "apollo-link-ws": "^1.0.12",
+        "apollo-utilities": "^1.0.27",
+        "cross-fetch": "^3.0.0",
+        "dss-common": "file:../dss/common",
+        "graphql": "^14.0.2",
+        "graphql-tag": "^2.10.0",
+        "node-fetch": "^2.3.0",
+        "subscriptions-transport-ws": "^0.9.15",
+        "uuid": "^3.3.2",
+        "webrtc-adapter": "^7.1.1",
+        "wrtc": "^0.3.4"
       },
       "dependencies": {
-        "@types/async": {
-          "version": "2.0.50",
-          "bundled": true,
-          "optional": true
-        },
         "@types/events": {
-          "version": "1.2.0",
+          "version": "3.0.0",
           "bundled": true
         },
         "@types/graphql": {
-          "version": "14.0.4",
+          "version": "14.0.6",
           "bundled": true
         },
         "@types/node": {
-          "version": "10.12.18",
+          "version": "10.12.25",
           "bundled": true
         },
         "@types/node-fetch": {
-          "version": "2.1.4",
+          "version": "2.1.6",
           "bundled": true,
           "requires": {
-            "@types/node": "10.12.18"
+            "@types/node": "*"
           }
         },
         "@types/uuid": {
           "version": "3.4.4",
           "bundled": true,
           "requires": {
-            "@types/node": "10.12.18"
+            "@types/node": "*"
           }
         },
         "@types/ws": {
           "version": "6.0.1",
           "bundled": true,
           "requires": {
-            "@types/events": "1.2.0",
-            "@types/node": "10.12.18"
+            "@types/events": "*",
+            "@types/node": "*"
           }
         },
         "@types/zen-observable": {
@@ -186,7 +230,7 @@
           "version": "1.7.11",
           "bundled": true,
           "requires": {
-            "@xtuc/ieee754": "1.2.0"
+            "@xtuc/ieee754": "^1.2.0"
           }
         },
         "@webassemblyjs/leb128": {
@@ -281,28 +325,21 @@
           "bundled": true
         },
         "acorn": {
-          "version": "5.7.3",
+          "version": "6.1.0",
           "bundled": true
         },
         "acorn-dynamic-import": {
-          "version": "3.0.0",
-          "bundled": true,
-          "requires": {
-            "acorn": "5.7.3"
-          }
-        },
-        "adapterjs": {
-          "version": "0.15.4",
+          "version": "4.0.0",
           "bundled": true
         },
         "ajv": {
-          "version": "6.7.0",
+          "version": "6.9.1",
           "bundled": true,
           "requires": {
-            "fast-deep-equal": "2.0.1",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.4.1",
-            "uri-js": "4.2.2"
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
           }
         },
         "ajv-errors": {
@@ -310,7 +347,7 @@
           "bundled": true
         },
         "ajv-keywords": {
-          "version": "3.2.0",
+          "version": "3.4.0",
           "bundled": true
         },
         "ansi-regex": {
@@ -318,92 +355,100 @@
           "bundled": true
         },
         "ansi-styles": {
-          "version": "3.2.1",
-          "bundled": true,
-          "requires": {
-            "color-convert": "1.9.3"
-          }
+          "version": "2.2.1",
+          "bundled": true
         },
         "anymatch": {
           "version": "2.0.0",
           "bundled": true,
           "requires": {
-            "micromatch": "3.1.10",
-            "normalize-path": "2.1.1"
+            "micromatch": "^3.1.4",
+            "normalize-path": "^2.1.1"
+          },
+          "dependencies": {
+            "normalize-path": {
+              "version": "2.1.1",
+              "bundled": true,
+              "requires": {
+                "remove-trailing-separator": "^1.0.1"
+              }
+            }
           }
         },
         "apollo-cache": {
-          "version": "1.1.22",
+          "version": "1.1.25",
           "bundled": true,
           "requires": {
-            "apollo-utilities": "1.0.27"
+            "apollo-utilities": "^1.1.2",
+            "tslib": "^1.9.3"
           }
         },
         "apollo-cache-inmemory": {
-          "version": "1.3.12",
+          "version": "1.4.2",
           "bundled": true,
           "requires": {
-            "apollo-cache": "1.1.22",
-            "apollo-utilities": "1.0.27",
-            "optimism": "0.6.8"
+            "apollo-cache": "^1.1.25",
+            "apollo-utilities": "^1.1.2",
+            "optimism": "^0.6.9",
+            "tslib": "^1.9.3"
           }
         },
         "apollo-client": {
-          "version": "2.4.8",
+          "version": "2.4.12",
           "bundled": true,
           "requires": {
-            "@types/async": "2.0.50",
-            "@types/zen-observable": "0.8.0",
-            "apollo-cache": "1.1.22",
-            "apollo-link": "1.2.6",
-            "apollo-link-dedup": "1.0.13",
-            "apollo-utilities": "1.0.27",
-            "symbol-observable": "1.2.0",
-            "zen-observable": "0.8.11"
+            "@types/zen-observable": "^0.8.0",
+            "apollo-cache": "1.1.25",
+            "apollo-link": "^1.0.0",
+            "apollo-link-dedup": "^1.0.0",
+            "apollo-utilities": "1.1.2",
+            "symbol-observable": "^1.0.2",
+            "tslib": "^1.9.3",
+            "zen-observable": "^0.8.0"
           }
         },
         "apollo-link": {
-          "version": "1.2.6",
+          "version": "1.2.8",
           "bundled": true,
           "requires": {
-            "apollo-utilities": "1.0.27",
-            "zen-observable-ts": "0.8.13"
+            "zen-observable-ts": "^0.8.15"
           }
         },
         "apollo-link-dedup": {
-          "version": "1.0.13",
+          "version": "1.0.15",
           "bundled": true,
           "requires": {
-            "apollo-link": "1.2.6"
+            "apollo-link": "^1.2.8"
           }
         },
         "apollo-link-http": {
-          "version": "1.5.9",
+          "version": "1.5.11",
           "bundled": true,
           "requires": {
-            "apollo-link": "1.2.6",
-            "apollo-link-http-common": "0.2.8"
+            "apollo-link": "^1.2.8",
+            "apollo-link-http-common": "^0.2.10"
           }
         },
         "apollo-link-http-common": {
-          "version": "0.2.8",
+          "version": "0.2.10",
           "bundled": true,
           "requires": {
-            "apollo-link": "1.2.6"
+            "apollo-link": "^1.2.8"
           }
         },
         "apollo-link-ws": {
-          "version": "1.0.12",
+          "version": "1.0.14",
           "bundled": true,
           "requires": {
-            "apollo-link": "1.2.6"
+            "apollo-link": "^1.2.8"
           }
         },
         "apollo-utilities": {
-          "version": "1.0.27",
+          "version": "1.1.2",
           "bundled": true,
           "requires": {
-            "fast-json-stable-stringify": "2.0.0"
+            "fast-json-stable-stringify": "^2.0.0",
+            "tslib": "^1.9.3"
           }
         },
         "aproba": {
@@ -414,15 +459,15 @@
           "version": "1.1.5",
           "bundled": true,
           "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.3.6"
+            "delegates": "^1.0.0",
+            "readable-stream": "^2.0.6"
           }
         },
         "argparse": {
           "version": "1.0.10",
           "bundled": true,
           "requires": {
-            "sprintf-js": "1.0.3"
+            "sprintf-js": "~1.0.2"
           }
         },
         "arr-diff": {
@@ -445,9 +490,9 @@
           "version": "4.10.1",
           "bundled": true,
           "requires": {
-            "bn.js": "4.11.8",
-            "inherits": "2.0.3",
-            "minimalistic-assert": "1.0.1"
+            "bn.js": "^4.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0"
           }
         },
         "assert": {
@@ -490,29 +535,21 @@
           "version": "6.26.0",
           "bundled": true,
           "requires": {
-            "chalk": "1.1.3",
-            "esutils": "2.0.2",
-            "js-tokens": "3.0.2"
+            "chalk": "^1.1.3",
+            "esutils": "^2.0.2",
+            "js-tokens": "^3.0.2"
           },
           "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.1",
-              "bundled": true
-            },
             "chalk": {
               "version": "1.1.3",
               "bundled": true,
               "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
               }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "bundled": true
             }
           }
         },
@@ -528,43 +565,43 @@
           "version": "0.11.2",
           "bundled": true,
           "requires": {
-            "cache-base": "1.0.1",
-            "class-utils": "0.3.6",
-            "component-emitter": "1.2.1",
-            "define-property": "1.0.0",
-            "isobject": "3.0.1",
-            "mixin-deep": "1.3.1",
-            "pascalcase": "0.1.1"
+            "cache-base": "^1.0.1",
+            "class-utils": "^0.3.5",
+            "component-emitter": "^1.2.1",
+            "define-property": "^1.0.0",
+            "isobject": "^3.0.1",
+            "mixin-deep": "^1.2.0",
+            "pascalcase": "^0.1.1"
           },
           "dependencies": {
             "define-property": {
               "version": "1.0.0",
               "bundled": true,
               "requires": {
-                "is-descriptor": "1.0.2"
+                "is-descriptor": "^1.0.0"
               }
             },
             "is-accessor-descriptor": {
               "version": "1.0.0",
               "bundled": true,
               "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.0"
               }
             },
             "is-data-descriptor": {
               "version": "1.0.0",
               "bundled": true,
               "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.0"
               }
             },
             "is-descriptor": {
               "version": "1.0.2",
               "bundled": true,
               "requires": {
-                "is-accessor-descriptor": "1.0.0",
-                "is-data-descriptor": "1.0.0",
-                "kind-of": "6.0.2"
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
               }
             }
           }
@@ -578,7 +615,7 @@
           "bundled": true
         },
         "binary-extensions": {
-          "version": "1.12.0",
+          "version": "1.13.0",
           "bundled": true
         },
         "bluebird": {
@@ -593,7 +630,7 @@
           "version": "1.1.11",
           "bundled": true,
           "requires": {
-            "balanced-match": "1.0.0",
+            "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -601,23 +638,23 @@
           "version": "2.3.2",
           "bundled": true,
           "requires": {
-            "arr-flatten": "1.1.0",
-            "array-unique": "0.3.2",
-            "extend-shallow": "2.0.1",
-            "fill-range": "4.0.0",
-            "isobject": "3.0.1",
-            "repeat-element": "1.1.3",
-            "snapdragon": "0.8.2",
-            "snapdragon-node": "2.1.1",
-            "split-string": "3.1.0",
-            "to-regex": "3.0.2"
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
               "bundled": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -630,68 +667,68 @@
           "version": "1.2.0",
           "bundled": true,
           "requires": {
-            "buffer-xor": "1.0.3",
-            "cipher-base": "1.0.4",
-            "create-hash": "1.2.0",
-            "evp_bytestokey": "1.0.3",
-            "inherits": "2.0.3",
-            "safe-buffer": "5.1.2"
+            "buffer-xor": "^1.0.3",
+            "cipher-base": "^1.0.0",
+            "create-hash": "^1.1.0",
+            "evp_bytestokey": "^1.0.3",
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
           }
         },
         "browserify-cipher": {
           "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "browserify-aes": "1.2.0",
-            "browserify-des": "1.0.2",
-            "evp_bytestokey": "1.0.3"
+            "browserify-aes": "^1.0.4",
+            "browserify-des": "^1.0.0",
+            "evp_bytestokey": "^1.0.0"
           }
         },
         "browserify-des": {
           "version": "1.0.2",
           "bundled": true,
           "requires": {
-            "cipher-base": "1.0.4",
-            "des.js": "1.0.0",
-            "inherits": "2.0.3",
-            "safe-buffer": "5.1.2"
+            "cipher-base": "^1.0.1",
+            "des.js": "^1.0.0",
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.1.2"
           }
         },
         "browserify-rsa": {
           "version": "4.0.1",
           "bundled": true,
           "requires": {
-            "bn.js": "4.11.8",
-            "randombytes": "2.0.6"
+            "bn.js": "^4.1.0",
+            "randombytes": "^2.0.1"
           }
         },
         "browserify-sign": {
           "version": "4.0.4",
           "bundled": true,
           "requires": {
-            "bn.js": "4.11.8",
-            "browserify-rsa": "4.0.1",
-            "create-hash": "1.2.0",
-            "create-hmac": "1.1.7",
-            "elliptic": "6.4.1",
-            "inherits": "2.0.3",
-            "parse-asn1": "5.1.3"
+            "bn.js": "^4.1.1",
+            "browserify-rsa": "^4.0.0",
+            "create-hash": "^1.1.0",
+            "create-hmac": "^1.1.2",
+            "elliptic": "^6.0.0",
+            "inherits": "^2.0.1",
+            "parse-asn1": "^5.0.0"
           }
         },
         "browserify-zlib": {
           "version": "0.2.0",
           "bundled": true,
           "requires": {
-            "pako": "1.0.8"
+            "pako": "~1.0.5"
           }
         },
         "buffer": {
           "version": "4.9.1",
           "bundled": true,
           "requires": {
-            "base64-js": "1.3.0",
-            "ieee754": "1.1.12",
-            "isarray": "1.0.0"
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4",
+            "isarray": "^1.0.0"
           }
         },
         "buffer-from": {
@@ -714,20 +751,20 @@
           "version": "11.3.2",
           "bundled": true,
           "requires": {
-            "bluebird": "3.5.3",
-            "chownr": "1.1.1",
-            "figgy-pudding": "3.5.1",
-            "glob": "7.1.3",
-            "graceful-fs": "4.1.15",
-            "lru-cache": "5.1.1",
-            "mississippi": "3.0.0",
-            "mkdirp": "0.5.1",
-            "move-concurrently": "1.0.1",
-            "promise-inflight": "1.0.1",
-            "rimraf": "2.6.3",
-            "ssri": "6.0.1",
-            "unique-filename": "1.1.1",
-            "y18n": "4.0.0"
+            "bluebird": "^3.5.3",
+            "chownr": "^1.1.1",
+            "figgy-pudding": "^3.5.1",
+            "glob": "^7.1.3",
+            "graceful-fs": "^4.1.15",
+            "lru-cache": "^5.1.1",
+            "mississippi": "^3.0.0",
+            "mkdirp": "^0.5.1",
+            "move-concurrently": "^1.0.1",
+            "promise-inflight": "^1.0.1",
+            "rimraf": "^2.6.2",
+            "ssri": "^6.0.1",
+            "unique-filename": "^1.1.1",
+            "y18n": "^4.0.0"
           },
           "dependencies": {
             "y18n": {
@@ -740,55 +777,70 @@
           "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "collection-visit": "1.0.0",
-            "component-emitter": "1.2.1",
-            "get-value": "2.0.6",
-            "has-value": "1.0.0",
-            "isobject": "3.0.1",
-            "set-value": "2.0.0",
-            "to-object-path": "0.3.0",
-            "union-value": "1.0.0",
-            "unset-value": "1.0.0"
+            "collection-visit": "^1.0.0",
+            "component-emitter": "^1.2.1",
+            "get-value": "^2.0.6",
+            "has-value": "^1.0.0",
+            "isobject": "^3.0.1",
+            "set-value": "^2.0.0",
+            "to-object-path": "^0.3.0",
+            "union-value": "^1.0.0",
+            "unset-value": "^1.0.0"
           }
         },
         "camelcase": {
           "version": "3.0.0",
           "bundled": true
         },
+        "canvas": {
+          "version": "2.3.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "nan": "^2.12.1",
+            "node-pre-gyp": "^0.11.0"
+          }
+        },
         "chalk": {
           "version": "2.4.2",
           "bundled": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.5.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "3.2.1",
+              "bundled": true,
+              "requires": {
+                "color-convert": "^1.9.0"
+              }
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "bundled": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
           }
         },
         "chokidar": {
-          "version": "2.0.4",
+          "version": "2.1.1",
           "bundled": true,
           "requires": {
-            "anymatch": "2.0.0",
-            "async-each": "1.0.1",
-            "braces": "2.3.2",
-            "glob-parent": "3.1.0",
-            "inherits": "2.0.3",
-            "is-binary-path": "1.0.1",
-            "is-glob": "4.0.0",
-            "lodash.debounce": "4.0.8",
-            "normalize-path": "2.1.1",
-            "path-is-absolute": "1.0.1",
-            "readdirp": "2.2.1",
-            "upath": "1.1.0"
-          },
-          "dependencies": {
-            "is-glob": {
-              "version": "4.0.0",
-              "bundled": true,
-              "requires": {
-                "is-extglob": "2.1.1"
-              }
-            }
+            "anymatch": "^2.0.0",
+            "async-each": "^1.0.1",
+            "braces": "^2.3.2",
+            "glob-parent": "^3.1.0",
+            "inherits": "^2.0.3",
+            "is-binary-path": "^1.0.0",
+            "is-glob": "^4.0.0",
+            "normalize-path": "^3.0.0",
+            "path-is-absolute": "^1.0.0",
+            "readdirp": "^2.2.1",
+            "upath": "^1.1.0"
           }
         },
         "chownr": {
@@ -799,32 +851,32 @@
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "tslib": "1.9.3"
+            "tslib": "^1.9.0"
           }
         },
         "cipher-base": {
           "version": "1.0.4",
           "bundled": true,
           "requires": {
-            "inherits": "2.0.3",
-            "safe-buffer": "5.1.2"
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
           }
         },
         "class-utils": {
           "version": "0.3.6",
           "bundled": true,
           "requires": {
-            "arr-union": "3.1.0",
-            "define-property": "0.2.5",
-            "isobject": "3.0.1",
-            "static-extend": "0.1.2"
+            "arr-union": "^3.1.0",
+            "define-property": "^0.2.5",
+            "isobject": "^3.0.0",
+            "static-extend": "^0.1.1"
           },
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
               "bundled": true,
               "requires": {
-                "is-descriptor": "0.1.6"
+                "is-descriptor": "^0.1.0"
               }
             }
           }
@@ -833,9 +885,9 @@
           "version": "3.2.0",
           "bundled": true,
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
           }
         },
         "code-point-at": {
@@ -846,8 +898,8 @@
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "map-visit": "1.0.0",
-            "object-visit": "1.0.1"
+            "map-visit": "^1.0.0",
+            "object-visit": "^1.0.0"
           }
         },
         "color-convert": {
@@ -881,17 +933,17 @@
           "version": "1.6.2",
           "bundled": true,
           "requires": {
-            "buffer-from": "1.1.1",
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.6",
-            "typedarray": "0.0.6"
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.2",
+            "typedarray": "^0.0.6"
           }
         },
         "console-browserify": {
           "version": "1.1.0",
           "bundled": true,
           "requires": {
-            "date-now": "0.1.4"
+            "date-now": "^0.1.4"
           }
         },
         "console-control-strings": {
@@ -906,12 +958,12 @@
           "version": "1.0.5",
           "bundled": true,
           "requires": {
-            "aproba": "1.2.0",
-            "fs-write-stream-atomic": "1.0.10",
-            "iferr": "0.1.5",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.3",
-            "run-queue": "1.0.3"
+            "aproba": "^1.1.1",
+            "fs-write-stream-atomic": "^1.0.8",
+            "iferr": "^0.1.5",
+            "mkdirp": "^0.5.1",
+            "rimraf": "^2.5.4",
+            "run-queue": "^1.0.0"
           }
         },
         "copy-descriptor": {
@@ -926,35 +978,35 @@
           "version": "4.0.3",
           "bundled": true,
           "requires": {
-            "bn.js": "4.11.8",
-            "elliptic": "6.4.1"
+            "bn.js": "^4.1.0",
+            "elliptic": "^6.0.0"
           }
         },
         "create-hash": {
           "version": "1.2.0",
           "bundled": true,
           "requires": {
-            "cipher-base": "1.0.4",
-            "inherits": "2.0.3",
-            "md5.js": "1.3.5",
-            "ripemd160": "2.0.2",
-            "sha.js": "2.4.11"
+            "cipher-base": "^1.0.1",
+            "inherits": "^2.0.1",
+            "md5.js": "^1.3.4",
+            "ripemd160": "^2.0.1",
+            "sha.js": "^2.4.0"
           }
         },
         "create-hmac": {
           "version": "1.1.7",
           "bundled": true,
           "requires": {
-            "cipher-base": "1.0.4",
-            "create-hash": "1.2.0",
-            "inherits": "2.0.3",
-            "ripemd160": "2.0.2",
-            "safe-buffer": "5.1.2",
-            "sha.js": "2.4.11"
+            "cipher-base": "^1.0.3",
+            "create-hash": "^1.1.0",
+            "inherits": "^2.0.1",
+            "ripemd160": "^2.0.0",
+            "safe-buffer": "^5.0.1",
+            "sha.js": "^2.4.8"
           }
         },
         "cross-fetch": {
-          "version": "3.0.0",
+          "version": "3.0.1",
           "bundled": true,
           "requires": {
             "node-fetch": "2.3.0",
@@ -965,28 +1017,28 @@
           "version": "6.0.5",
           "bundled": true,
           "requires": {
-            "nice-try": "1.0.5",
-            "path-key": "2.0.1",
-            "semver": "5.6.0",
-            "shebang-command": "1.2.0",
-            "which": "1.3.1"
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
           }
         },
         "crypto-browserify": {
           "version": "3.12.0",
           "bundled": true,
           "requires": {
-            "browserify-cipher": "1.0.1",
-            "browserify-sign": "4.0.4",
-            "create-ecdh": "4.0.3",
-            "create-hash": "1.2.0",
-            "create-hmac": "1.1.7",
-            "diffie-hellman": "5.0.3",
-            "inherits": "2.0.3",
-            "pbkdf2": "3.0.17",
-            "public-encrypt": "4.0.3",
-            "randombytes": "2.0.6",
-            "randomfill": "1.0.4"
+            "browserify-cipher": "^1.0.0",
+            "browserify-sign": "^4.0.0",
+            "create-ecdh": "^4.0.0",
+            "create-hash": "^1.1.0",
+            "create-hmac": "^1.1.0",
+            "diffie-hellman": "^5.0.0",
+            "inherits": "^2.0.1",
+            "pbkdf2": "^3.0.3",
+            "public-encrypt": "^4.0.0",
+            "randombytes": "^2.0.0",
+            "randomfill": "^1.0.3"
           }
         },
         "cyclist": {
@@ -1020,31 +1072,31 @@
           "version": "2.0.2",
           "bundled": true,
           "requires": {
-            "is-descriptor": "1.0.2",
-            "isobject": "3.0.1"
+            "is-descriptor": "^1.0.2",
+            "isobject": "^3.0.1"
           },
           "dependencies": {
             "is-accessor-descriptor": {
               "version": "1.0.0",
               "bundled": true,
               "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.0"
               }
             },
             "is-data-descriptor": {
               "version": "1.0.0",
               "bundled": true,
               "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.0"
               }
             },
             "is-descriptor": {
               "version": "1.0.2",
               "bundled": true,
               "requires": {
-                "is-accessor-descriptor": "1.0.0",
-                "is-data-descriptor": "1.0.0",
-                "kind-of": "6.0.2"
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
               }
             }
           }
@@ -1057,8 +1109,8 @@
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "inherits": "2.0.3",
-            "minimalistic-assert": "1.0.1"
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0"
           }
         },
         "detect-file": {
@@ -1077,9 +1129,9 @@
           "version": "5.0.3",
           "bundled": true,
           "requires": {
-            "bn.js": "4.11.8",
-            "miller-rabin": "4.0.1",
-            "randombytes": "2.0.6"
+            "bn.js": "^4.1.0",
+            "miller-rabin": "^4.0.0",
+            "randombytes": "^2.0.0"
           }
         },
         "domain-browser": {
@@ -1087,61 +1139,61 @@
           "bundled": true
         },
         "dss-common": {
-          "version": "0.1.0",
+          "version": "file:../dss/common",
           "bundled": true,
           "requires": {
-            "graphql": "14.1.1",
-            "graphql-tag": "2.10.1"
+            "graphql": "^14.1.1",
+            "graphql-tag": "^2.10.1"
           },
           "dependencies": {
             "@babel/cli": {
               "version": "7.2.3",
               "bundled": true,
               "requires": {
-                "chokidar": "2.0.4",
-                "commander": "2.19.0",
-                "convert-source-map": "1.6.0",
-                "fs-readdir-recursive": "1.1.0",
-                "glob": "7.1.3",
-                "lodash": "4.17.11",
-                "mkdirp": "0.5.1",
-                "output-file-sync": "2.0.1",
-                "slash": "2.0.0",
-                "source-map": "0.5.7"
+                "chokidar": "^2.0.3",
+                "commander": "^2.8.1",
+                "convert-source-map": "^1.1.0",
+                "fs-readdir-recursive": "^1.1.0",
+                "glob": "^7.0.0",
+                "lodash": "^4.17.10",
+                "mkdirp": "^0.5.1",
+                "output-file-sync": "^2.0.0",
+                "slash": "^2.0.0",
+                "source-map": "^0.5.0"
               }
             },
             "@babel/code-frame": {
               "version": "7.0.0",
               "bundled": true,
               "requires": {
-                "@babel/highlight": "7.0.0"
+                "@babel/highlight": "^7.0.0"
               }
             },
             "@babel/core": {
               "version": "7.2.2",
               "bundled": true,
               "requires": {
-                "@babel/code-frame": "7.0.0",
-                "@babel/generator": "7.3.0",
-                "@babel/helpers": "7.3.0",
-                "@babel/parser": "7.3.0",
-                "@babel/template": "7.2.2",
-                "@babel/traverse": "7.2.3",
-                "@babel/types": "7.3.0",
-                "convert-source-map": "1.6.0",
-                "debug": "4.1.1",
-                "json5": "2.1.0",
-                "lodash": "4.17.11",
-                "resolve": "1.10.0",
-                "semver": "5.6.0",
-                "source-map": "0.5.7"
+                "@babel/code-frame": "^7.0.0",
+                "@babel/generator": "^7.2.2",
+                "@babel/helpers": "^7.2.0",
+                "@babel/parser": "^7.2.2",
+                "@babel/template": "^7.2.2",
+                "@babel/traverse": "^7.2.2",
+                "@babel/types": "^7.2.2",
+                "convert-source-map": "^1.1.0",
+                "debug": "^4.1.0",
+                "json5": "^2.1.0",
+                "lodash": "^4.17.10",
+                "resolve": "^1.3.2",
+                "semver": "^5.4.1",
+                "source-map": "^0.5.0"
               },
               "dependencies": {
                 "debug": {
                   "version": "4.1.1",
                   "bundled": true,
                   "requires": {
-                    "ms": "2.1.1"
+                    "ms": "^2.1.1"
                   }
                 },
                 "ms": {
@@ -1154,119 +1206,119 @@
               "version": "7.3.0",
               "bundled": true,
               "requires": {
-                "@babel/types": "7.3.0",
-                "jsesc": "2.5.2",
-                "lodash": "4.17.11",
-                "source-map": "0.5.7",
-                "trim-right": "1.0.1"
+                "@babel/types": "^7.3.0",
+                "jsesc": "^2.5.1",
+                "lodash": "^4.17.10",
+                "source-map": "^0.5.0",
+                "trim-right": "^1.0.1"
               }
             },
             "@babel/helper-annotate-as-pure": {
               "version": "7.0.0",
               "bundled": true,
               "requires": {
-                "@babel/types": "7.3.0"
+                "@babel/types": "^7.0.0"
               }
             },
             "@babel/helper-builder-binary-assignment-operator-visitor": {
               "version": "7.1.0",
               "bundled": true,
               "requires": {
-                "@babel/helper-explode-assignable-expression": "7.1.0",
-                "@babel/types": "7.3.0"
+                "@babel/helper-explode-assignable-expression": "^7.1.0",
+                "@babel/types": "^7.0.0"
               }
             },
             "@babel/helper-call-delegate": {
               "version": "7.1.0",
               "bundled": true,
               "requires": {
-                "@babel/helper-hoist-variables": "7.0.0",
-                "@babel/traverse": "7.2.3",
-                "@babel/types": "7.3.0"
+                "@babel/helper-hoist-variables": "^7.0.0",
+                "@babel/traverse": "^7.1.0",
+                "@babel/types": "^7.0.0"
               }
             },
             "@babel/helper-create-class-features-plugin": {
               "version": "7.3.0",
               "bundled": true,
               "requires": {
-                "@babel/helper-function-name": "7.1.0",
-                "@babel/helper-member-expression-to-functions": "7.0.0",
-                "@babel/helper-optimise-call-expression": "7.0.0",
-                "@babel/helper-plugin-utils": "7.0.0",
-                "@babel/helper-replace-supers": "7.2.3"
+                "@babel/helper-function-name": "^7.1.0",
+                "@babel/helper-member-expression-to-functions": "^7.0.0",
+                "@babel/helper-optimise-call-expression": "^7.0.0",
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-replace-supers": "^7.2.3"
               }
             },
             "@babel/helper-define-map": {
               "version": "7.1.0",
               "bundled": true,
               "requires": {
-                "@babel/helper-function-name": "7.1.0",
-                "@babel/types": "7.3.0",
-                "lodash": "4.17.11"
+                "@babel/helper-function-name": "^7.1.0",
+                "@babel/types": "^7.0.0",
+                "lodash": "^4.17.10"
               }
             },
             "@babel/helper-explode-assignable-expression": {
               "version": "7.1.0",
               "bundled": true,
               "requires": {
-                "@babel/traverse": "7.2.3",
-                "@babel/types": "7.3.0"
+                "@babel/traverse": "^7.1.0",
+                "@babel/types": "^7.0.0"
               }
             },
             "@babel/helper-function-name": {
               "version": "7.1.0",
               "bundled": true,
               "requires": {
-                "@babel/helper-get-function-arity": "7.0.0",
-                "@babel/template": "7.2.2",
-                "@babel/types": "7.3.0"
+                "@babel/helper-get-function-arity": "^7.0.0",
+                "@babel/template": "^7.1.0",
+                "@babel/types": "^7.0.0"
               }
             },
             "@babel/helper-get-function-arity": {
               "version": "7.0.0",
               "bundled": true,
               "requires": {
-                "@babel/types": "7.3.0"
+                "@babel/types": "^7.0.0"
               }
             },
             "@babel/helper-hoist-variables": {
               "version": "7.0.0",
               "bundled": true,
               "requires": {
-                "@babel/types": "7.3.0"
+                "@babel/types": "^7.0.0"
               }
             },
             "@babel/helper-member-expression-to-functions": {
               "version": "7.0.0",
               "bundled": true,
               "requires": {
-                "@babel/types": "7.3.0"
+                "@babel/types": "^7.0.0"
               }
             },
             "@babel/helper-module-imports": {
               "version": "7.0.0",
               "bundled": true,
               "requires": {
-                "@babel/types": "7.3.0"
+                "@babel/types": "^7.0.0"
               }
             },
             "@babel/helper-module-transforms": {
               "version": "7.2.2",
               "bundled": true,
               "requires": {
-                "@babel/helper-module-imports": "7.0.0",
-                "@babel/helper-simple-access": "7.1.0",
-                "@babel/helper-split-export-declaration": "7.0.0",
-                "@babel/template": "7.2.2",
-                "@babel/types": "7.3.0",
-                "lodash": "4.17.11"
+                "@babel/helper-module-imports": "^7.0.0",
+                "@babel/helper-simple-access": "^7.1.0",
+                "@babel/helper-split-export-declaration": "^7.0.0",
+                "@babel/template": "^7.2.2",
+                "@babel/types": "^7.2.2",
+                "lodash": "^4.17.10"
               }
             },
             "@babel/helper-optimise-call-expression": {
               "version": "7.0.0",
               "bundled": true,
               "requires": {
-                "@babel/types": "7.3.0"
+                "@babel/types": "^7.0.0"
               }
             },
             "@babel/helper-plugin-utils": {
@@ -1277,71 +1329,71 @@
               "version": "7.0.0",
               "bundled": true,
               "requires": {
-                "lodash": "4.17.11"
+                "lodash": "^4.17.10"
               }
             },
             "@babel/helper-remap-async-to-generator": {
               "version": "7.1.0",
               "bundled": true,
               "requires": {
-                "@babel/helper-annotate-as-pure": "7.0.0",
-                "@babel/helper-wrap-function": "7.2.0",
-                "@babel/template": "7.2.2",
-                "@babel/traverse": "7.2.3",
-                "@babel/types": "7.3.0"
+                "@babel/helper-annotate-as-pure": "^7.0.0",
+                "@babel/helper-wrap-function": "^7.1.0",
+                "@babel/template": "^7.1.0",
+                "@babel/traverse": "^7.1.0",
+                "@babel/types": "^7.0.0"
               }
             },
             "@babel/helper-replace-supers": {
               "version": "7.2.3",
               "bundled": true,
               "requires": {
-                "@babel/helper-member-expression-to-functions": "7.0.0",
-                "@babel/helper-optimise-call-expression": "7.0.0",
-                "@babel/traverse": "7.2.3",
-                "@babel/types": "7.3.0"
+                "@babel/helper-member-expression-to-functions": "^7.0.0",
+                "@babel/helper-optimise-call-expression": "^7.0.0",
+                "@babel/traverse": "^7.2.3",
+                "@babel/types": "^7.0.0"
               }
             },
             "@babel/helper-simple-access": {
               "version": "7.1.0",
               "bundled": true,
               "requires": {
-                "@babel/template": "7.2.2",
-                "@babel/types": "7.3.0"
+                "@babel/template": "^7.1.0",
+                "@babel/types": "^7.0.0"
               }
             },
             "@babel/helper-split-export-declaration": {
               "version": "7.0.0",
               "bundled": true,
               "requires": {
-                "@babel/types": "7.3.0"
+                "@babel/types": "^7.0.0"
               }
             },
             "@babel/helper-wrap-function": {
               "version": "7.2.0",
               "bundled": true,
               "requires": {
-                "@babel/helper-function-name": "7.1.0",
-                "@babel/template": "7.2.2",
-                "@babel/traverse": "7.2.3",
-                "@babel/types": "7.3.0"
+                "@babel/helper-function-name": "^7.1.0",
+                "@babel/template": "^7.1.0",
+                "@babel/traverse": "^7.1.0",
+                "@babel/types": "^7.2.0"
               }
             },
             "@babel/helpers": {
               "version": "7.3.0",
               "bundled": true,
               "requires": {
-                "@babel/template": "7.2.2",
-                "@babel/traverse": "7.2.3",
-                "@babel/types": "7.3.0"
+                "@babel/template": "^7.1.2",
+                "@babel/traverse": "^7.1.5",
+                "@babel/types": "^7.3.0"
               }
             },
             "@babel/highlight": {
               "version": "7.0.0",
               "bundled": true,
               "requires": {
-                "chalk": "2.4.2",
-                "esutils": "2.0.2",
-                "js-tokens": "4.0.0"
+                "chalk": "^2.0.0",
+                "esutils": "^2.0.2",
+                "js-tokens": "^4.0.0"
               },
               "dependencies": {
                 "js-tokens": {
@@ -1358,403 +1410,403 @@
               "version": "7.2.0",
               "bundled": true,
               "requires": {
-                "@babel/helper-plugin-utils": "7.0.0",
-                "@babel/helper-remap-async-to-generator": "7.1.0",
-                "@babel/plugin-syntax-async-generators": "7.2.0"
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-remap-async-to-generator": "^7.1.0",
+                "@babel/plugin-syntax-async-generators": "^7.2.0"
               }
             },
             "@babel/plugin-proposal-class-properties": {
               "version": "7.3.0",
               "bundled": true,
               "requires": {
-                "@babel/helper-create-class-features-plugin": "7.3.0",
-                "@babel/helper-plugin-utils": "7.0.0"
+                "@babel/helper-create-class-features-plugin": "^7.3.0",
+                "@babel/helper-plugin-utils": "^7.0.0"
               }
             },
             "@babel/plugin-proposal-json-strings": {
               "version": "7.2.0",
               "bundled": true,
               "requires": {
-                "@babel/helper-plugin-utils": "7.0.0",
-                "@babel/plugin-syntax-json-strings": "7.2.0"
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/plugin-syntax-json-strings": "^7.2.0"
               }
             },
             "@babel/plugin-proposal-object-rest-spread": {
               "version": "7.3.0",
               "bundled": true,
               "requires": {
-                "@babel/helper-plugin-utils": "7.0.0",
-                "@babel/plugin-syntax-object-rest-spread": "7.2.0"
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/plugin-syntax-object-rest-spread": "^7.2.0"
               }
             },
             "@babel/plugin-proposal-optional-catch-binding": {
               "version": "7.2.0",
               "bundled": true,
               "requires": {
-                "@babel/helper-plugin-utils": "7.0.0",
-                "@babel/plugin-syntax-optional-catch-binding": "7.2.0"
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/plugin-syntax-optional-catch-binding": "^7.2.0"
               }
             },
             "@babel/plugin-proposal-unicode-property-regex": {
               "version": "7.2.0",
               "bundled": true,
               "requires": {
-                "@babel/helper-plugin-utils": "7.0.0",
-                "@babel/helper-regex": "7.0.0",
-                "regexpu-core": "4.4.0"
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-regex": "^7.0.0",
+                "regexpu-core": "^4.2.0"
               }
             },
             "@babel/plugin-syntax-async-generators": {
               "version": "7.2.0",
               "bundled": true,
               "requires": {
-                "@babel/helper-plugin-utils": "7.0.0"
+                "@babel/helper-plugin-utils": "^7.0.0"
               }
             },
             "@babel/plugin-syntax-json-strings": {
               "version": "7.2.0",
               "bundled": true,
               "requires": {
-                "@babel/helper-plugin-utils": "7.0.0"
+                "@babel/helper-plugin-utils": "^7.0.0"
               }
             },
             "@babel/plugin-syntax-object-rest-spread": {
               "version": "7.2.0",
               "bundled": true,
               "requires": {
-                "@babel/helper-plugin-utils": "7.0.0"
+                "@babel/helper-plugin-utils": "^7.0.0"
               }
             },
             "@babel/plugin-syntax-optional-catch-binding": {
               "version": "7.2.0",
               "bundled": true,
               "requires": {
-                "@babel/helper-plugin-utils": "7.0.0"
+                "@babel/helper-plugin-utils": "^7.0.0"
               }
             },
             "@babel/plugin-syntax-typescript": {
               "version": "7.2.0",
               "bundled": true,
               "requires": {
-                "@babel/helper-plugin-utils": "7.0.0"
+                "@babel/helper-plugin-utils": "^7.0.0"
               }
             },
             "@babel/plugin-transform-arrow-functions": {
               "version": "7.2.0",
               "bundled": true,
               "requires": {
-                "@babel/helper-plugin-utils": "7.0.0"
+                "@babel/helper-plugin-utils": "^7.0.0"
               }
             },
             "@babel/plugin-transform-async-to-generator": {
               "version": "7.2.0",
               "bundled": true,
               "requires": {
-                "@babel/helper-module-imports": "7.0.0",
-                "@babel/helper-plugin-utils": "7.0.0",
-                "@babel/helper-remap-async-to-generator": "7.1.0"
+                "@babel/helper-module-imports": "^7.0.0",
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-remap-async-to-generator": "^7.1.0"
               }
             },
             "@babel/plugin-transform-block-scoped-functions": {
               "version": "7.2.0",
               "bundled": true,
               "requires": {
-                "@babel/helper-plugin-utils": "7.0.0"
+                "@babel/helper-plugin-utils": "^7.0.0"
               }
             },
             "@babel/plugin-transform-block-scoping": {
               "version": "7.2.0",
               "bundled": true,
               "requires": {
-                "@babel/helper-plugin-utils": "7.0.0",
-                "lodash": "4.17.11"
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "lodash": "^4.17.10"
               }
             },
             "@babel/plugin-transform-classes": {
               "version": "7.2.2",
               "bundled": true,
               "requires": {
-                "@babel/helper-annotate-as-pure": "7.0.0",
-                "@babel/helper-define-map": "7.1.0",
-                "@babel/helper-function-name": "7.1.0",
-                "@babel/helper-optimise-call-expression": "7.0.0",
-                "@babel/helper-plugin-utils": "7.0.0",
-                "@babel/helper-replace-supers": "7.2.3",
-                "@babel/helper-split-export-declaration": "7.0.0",
-                "globals": "11.10.0"
+                "@babel/helper-annotate-as-pure": "^7.0.0",
+                "@babel/helper-define-map": "^7.1.0",
+                "@babel/helper-function-name": "^7.1.0",
+                "@babel/helper-optimise-call-expression": "^7.0.0",
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-replace-supers": "^7.1.0",
+                "@babel/helper-split-export-declaration": "^7.0.0",
+                "globals": "^11.1.0"
               }
             },
             "@babel/plugin-transform-computed-properties": {
               "version": "7.2.0",
               "bundled": true,
               "requires": {
-                "@babel/helper-plugin-utils": "7.0.0"
+                "@babel/helper-plugin-utils": "^7.0.0"
               }
             },
             "@babel/plugin-transform-destructuring": {
               "version": "7.2.0",
               "bundled": true,
               "requires": {
-                "@babel/helper-plugin-utils": "7.0.0"
+                "@babel/helper-plugin-utils": "^7.0.0"
               }
             },
             "@babel/plugin-transform-dotall-regex": {
               "version": "7.2.0",
               "bundled": true,
               "requires": {
-                "@babel/helper-plugin-utils": "7.0.0",
-                "@babel/helper-regex": "7.0.0",
-                "regexpu-core": "4.4.0"
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-regex": "^7.0.0",
+                "regexpu-core": "^4.1.3"
               }
             },
             "@babel/plugin-transform-duplicate-keys": {
               "version": "7.2.0",
               "bundled": true,
               "requires": {
-                "@babel/helper-plugin-utils": "7.0.0"
+                "@babel/helper-plugin-utils": "^7.0.0"
               }
             },
             "@babel/plugin-transform-exponentiation-operator": {
               "version": "7.2.0",
               "bundled": true,
               "requires": {
-                "@babel/helper-builder-binary-assignment-operator-visitor": "7.1.0",
-                "@babel/helper-plugin-utils": "7.0.0"
+                "@babel/helper-builder-binary-assignment-operator-visitor": "^7.1.0",
+                "@babel/helper-plugin-utils": "^7.0.0"
               }
             },
             "@babel/plugin-transform-for-of": {
               "version": "7.2.0",
               "bundled": true,
               "requires": {
-                "@babel/helper-plugin-utils": "7.0.0"
+                "@babel/helper-plugin-utils": "^7.0.0"
               }
             },
             "@babel/plugin-transform-function-name": {
               "version": "7.2.0",
               "bundled": true,
               "requires": {
-                "@babel/helper-function-name": "7.1.0",
-                "@babel/helper-plugin-utils": "7.0.0"
+                "@babel/helper-function-name": "^7.1.0",
+                "@babel/helper-plugin-utils": "^7.0.0"
               }
             },
             "@babel/plugin-transform-literals": {
               "version": "7.2.0",
               "bundled": true,
               "requires": {
-                "@babel/helper-plugin-utils": "7.0.0"
+                "@babel/helper-plugin-utils": "^7.0.0"
               }
             },
             "@babel/plugin-transform-modules-amd": {
               "version": "7.2.0",
               "bundled": true,
               "requires": {
-                "@babel/helper-module-transforms": "7.2.2",
-                "@babel/helper-plugin-utils": "7.0.0"
+                "@babel/helper-module-transforms": "^7.1.0",
+                "@babel/helper-plugin-utils": "^7.0.0"
               }
             },
             "@babel/plugin-transform-modules-commonjs": {
               "version": "7.2.0",
               "bundled": true,
               "requires": {
-                "@babel/helper-module-transforms": "7.2.2",
-                "@babel/helper-plugin-utils": "7.0.0",
-                "@babel/helper-simple-access": "7.1.0"
+                "@babel/helper-module-transforms": "^7.1.0",
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-simple-access": "^7.1.0"
               }
             },
             "@babel/plugin-transform-modules-systemjs": {
               "version": "7.2.0",
               "bundled": true,
               "requires": {
-                "@babel/helper-hoist-variables": "7.0.0",
-                "@babel/helper-plugin-utils": "7.0.0"
+                "@babel/helper-hoist-variables": "^7.0.0",
+                "@babel/helper-plugin-utils": "^7.0.0"
               }
             },
             "@babel/plugin-transform-modules-umd": {
               "version": "7.2.0",
               "bundled": true,
               "requires": {
-                "@babel/helper-module-transforms": "7.2.2",
-                "@babel/helper-plugin-utils": "7.0.0"
+                "@babel/helper-module-transforms": "^7.1.0",
+                "@babel/helper-plugin-utils": "^7.0.0"
               }
             },
             "@babel/plugin-transform-named-capturing-groups-regex": {
               "version": "7.3.0",
               "bundled": true,
               "requires": {
-                "regexp-tree": "0.1.0"
+                "regexp-tree": "^0.1.0"
               }
             },
             "@babel/plugin-transform-new-target": {
               "version": "7.0.0",
               "bundled": true,
               "requires": {
-                "@babel/helper-plugin-utils": "7.0.0"
+                "@babel/helper-plugin-utils": "^7.0.0"
               }
             },
             "@babel/plugin-transform-object-super": {
               "version": "7.2.0",
               "bundled": true,
               "requires": {
-                "@babel/helper-plugin-utils": "7.0.0",
-                "@babel/helper-replace-supers": "7.2.3"
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-replace-supers": "^7.1.0"
               }
             },
             "@babel/plugin-transform-parameters": {
               "version": "7.2.0",
               "bundled": true,
               "requires": {
-                "@babel/helper-call-delegate": "7.1.0",
-                "@babel/helper-get-function-arity": "7.0.0",
-                "@babel/helper-plugin-utils": "7.0.0"
+                "@babel/helper-call-delegate": "^7.1.0",
+                "@babel/helper-get-function-arity": "^7.0.0",
+                "@babel/helper-plugin-utils": "^7.0.0"
               }
             },
             "@babel/plugin-transform-regenerator": {
               "version": "7.0.0",
               "bundled": true,
               "requires": {
-                "regenerator-transform": "0.13.3"
+                "regenerator-transform": "^0.13.3"
               }
             },
             "@babel/plugin-transform-shorthand-properties": {
               "version": "7.2.0",
               "bundled": true,
               "requires": {
-                "@babel/helper-plugin-utils": "7.0.0"
+                "@babel/helper-plugin-utils": "^7.0.0"
               }
             },
             "@babel/plugin-transform-spread": {
               "version": "7.2.2",
               "bundled": true,
               "requires": {
-                "@babel/helper-plugin-utils": "7.0.0"
+                "@babel/helper-plugin-utils": "^7.0.0"
               }
             },
             "@babel/plugin-transform-sticky-regex": {
               "version": "7.2.0",
               "bundled": true,
               "requires": {
-                "@babel/helper-plugin-utils": "7.0.0",
-                "@babel/helper-regex": "7.0.0"
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-regex": "^7.0.0"
               }
             },
             "@babel/plugin-transform-template-literals": {
               "version": "7.2.0",
               "bundled": true,
               "requires": {
-                "@babel/helper-annotate-as-pure": "7.0.0",
-                "@babel/helper-plugin-utils": "7.0.0"
+                "@babel/helper-annotate-as-pure": "^7.0.0",
+                "@babel/helper-plugin-utils": "^7.0.0"
               }
             },
             "@babel/plugin-transform-typeof-symbol": {
               "version": "7.2.0",
               "bundled": true,
               "requires": {
-                "@babel/helper-plugin-utils": "7.0.0"
+                "@babel/helper-plugin-utils": "^7.0.0"
               }
             },
             "@babel/plugin-transform-typescript": {
               "version": "7.2.0",
               "bundled": true,
               "requires": {
-                "@babel/helper-plugin-utils": "7.0.0",
-                "@babel/plugin-syntax-typescript": "7.2.0"
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/plugin-syntax-typescript": "^7.2.0"
               }
             },
             "@babel/plugin-transform-unicode-regex": {
               "version": "7.2.0",
               "bundled": true,
               "requires": {
-                "@babel/helper-plugin-utils": "7.0.0",
-                "@babel/helper-regex": "7.0.0",
-                "regexpu-core": "4.4.0"
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/helper-regex": "^7.0.0",
+                "regexpu-core": "^4.1.3"
               }
             },
             "@babel/preset-env": {
               "version": "7.3.0",
               "bundled": true,
               "requires": {
-                "@babel/helper-module-imports": "7.0.0",
-                "@babel/helper-plugin-utils": "7.0.0",
-                "@babel/plugin-proposal-async-generator-functions": "7.2.0",
-                "@babel/plugin-proposal-json-strings": "7.2.0",
-                "@babel/plugin-proposal-object-rest-spread": "7.3.0",
-                "@babel/plugin-proposal-optional-catch-binding": "7.2.0",
-                "@babel/plugin-proposal-unicode-property-regex": "7.2.0",
-                "@babel/plugin-syntax-async-generators": "7.2.0",
-                "@babel/plugin-syntax-json-strings": "7.2.0",
-                "@babel/plugin-syntax-object-rest-spread": "7.2.0",
-                "@babel/plugin-syntax-optional-catch-binding": "7.2.0",
-                "@babel/plugin-transform-arrow-functions": "7.2.0",
-                "@babel/plugin-transform-async-to-generator": "7.2.0",
-                "@babel/plugin-transform-block-scoped-functions": "7.2.0",
-                "@babel/plugin-transform-block-scoping": "7.2.0",
-                "@babel/plugin-transform-classes": "7.2.2",
-                "@babel/plugin-transform-computed-properties": "7.2.0",
-                "@babel/plugin-transform-destructuring": "7.2.0",
-                "@babel/plugin-transform-dotall-regex": "7.2.0",
-                "@babel/plugin-transform-duplicate-keys": "7.2.0",
-                "@babel/plugin-transform-exponentiation-operator": "7.2.0",
-                "@babel/plugin-transform-for-of": "7.2.0",
-                "@babel/plugin-transform-function-name": "7.2.0",
-                "@babel/plugin-transform-literals": "7.2.0",
-                "@babel/plugin-transform-modules-amd": "7.2.0",
-                "@babel/plugin-transform-modules-commonjs": "7.2.0",
-                "@babel/plugin-transform-modules-systemjs": "7.2.0",
-                "@babel/plugin-transform-modules-umd": "7.2.0",
-                "@babel/plugin-transform-named-capturing-groups-regex": "7.3.0",
-                "@babel/plugin-transform-new-target": "7.0.0",
-                "@babel/plugin-transform-object-super": "7.2.0",
-                "@babel/plugin-transform-parameters": "7.2.0",
-                "@babel/plugin-transform-regenerator": "7.0.0",
-                "@babel/plugin-transform-shorthand-properties": "7.2.0",
-                "@babel/plugin-transform-spread": "7.2.2",
-                "@babel/plugin-transform-sticky-regex": "7.2.0",
-                "@babel/plugin-transform-template-literals": "7.2.0",
-                "@babel/plugin-transform-typeof-symbol": "7.2.0",
-                "@babel/plugin-transform-unicode-regex": "7.2.0",
-                "browserslist": "4.4.1",
-                "invariant": "2.2.4",
-                "js-levenshtein": "1.1.6",
-                "semver": "5.6.0"
+                "@babel/helper-module-imports": "^7.0.0",
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/plugin-proposal-async-generator-functions": "^7.2.0",
+                "@babel/plugin-proposal-json-strings": "^7.2.0",
+                "@babel/plugin-proposal-object-rest-spread": "^7.3.0",
+                "@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
+                "@babel/plugin-proposal-unicode-property-regex": "^7.2.0",
+                "@babel/plugin-syntax-async-generators": "^7.2.0",
+                "@babel/plugin-syntax-json-strings": "^7.2.0",
+                "@babel/plugin-syntax-object-rest-spread": "^7.2.0",
+                "@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
+                "@babel/plugin-transform-arrow-functions": "^7.2.0",
+                "@babel/plugin-transform-async-to-generator": "^7.2.0",
+                "@babel/plugin-transform-block-scoped-functions": "^7.2.0",
+                "@babel/plugin-transform-block-scoping": "^7.2.0",
+                "@babel/plugin-transform-classes": "^7.2.0",
+                "@babel/plugin-transform-computed-properties": "^7.2.0",
+                "@babel/plugin-transform-destructuring": "^7.2.0",
+                "@babel/plugin-transform-dotall-regex": "^7.2.0",
+                "@babel/plugin-transform-duplicate-keys": "^7.2.0",
+                "@babel/plugin-transform-exponentiation-operator": "^7.2.0",
+                "@babel/plugin-transform-for-of": "^7.2.0",
+                "@babel/plugin-transform-function-name": "^7.2.0",
+                "@babel/plugin-transform-literals": "^7.2.0",
+                "@babel/plugin-transform-modules-amd": "^7.2.0",
+                "@babel/plugin-transform-modules-commonjs": "^7.2.0",
+                "@babel/plugin-transform-modules-systemjs": "^7.2.0",
+                "@babel/plugin-transform-modules-umd": "^7.2.0",
+                "@babel/plugin-transform-named-capturing-groups-regex": "^7.3.0",
+                "@babel/plugin-transform-new-target": "^7.0.0",
+                "@babel/plugin-transform-object-super": "^7.2.0",
+                "@babel/plugin-transform-parameters": "^7.2.0",
+                "@babel/plugin-transform-regenerator": "^7.0.0",
+                "@babel/plugin-transform-shorthand-properties": "^7.2.0",
+                "@babel/plugin-transform-spread": "^7.2.0",
+                "@babel/plugin-transform-sticky-regex": "^7.2.0",
+                "@babel/plugin-transform-template-literals": "^7.2.0",
+                "@babel/plugin-transform-typeof-symbol": "^7.2.0",
+                "@babel/plugin-transform-unicode-regex": "^7.2.0",
+                "browserslist": "^4.3.4",
+                "invariant": "^2.2.2",
+                "js-levenshtein": "^1.1.3",
+                "semver": "^5.3.0"
               }
             },
             "@babel/preset-typescript": {
               "version": "7.1.0",
               "bundled": true,
               "requires": {
-                "@babel/helper-plugin-utils": "7.0.0",
-                "@babel/plugin-transform-typescript": "7.2.0"
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/plugin-transform-typescript": "^7.1.0"
               }
             },
             "@babel/template": {
               "version": "7.2.2",
               "bundled": true,
               "requires": {
-                "@babel/code-frame": "7.0.0",
-                "@babel/parser": "7.3.0",
-                "@babel/types": "7.3.0"
+                "@babel/code-frame": "^7.0.0",
+                "@babel/parser": "^7.2.2",
+                "@babel/types": "^7.2.2"
               }
             },
             "@babel/traverse": {
               "version": "7.2.3",
               "bundled": true,
               "requires": {
-                "@babel/code-frame": "7.0.0",
-                "@babel/generator": "7.3.0",
-                "@babel/helper-function-name": "7.1.0",
-                "@babel/helper-split-export-declaration": "7.0.0",
-                "@babel/parser": "7.3.0",
-                "@babel/types": "7.3.0",
-                "debug": "4.1.1",
-                "globals": "11.10.0",
-                "lodash": "4.17.11"
+                "@babel/code-frame": "^7.0.0",
+                "@babel/generator": "^7.2.2",
+                "@babel/helper-function-name": "^7.1.0",
+                "@babel/helper-split-export-declaration": "^7.0.0",
+                "@babel/parser": "^7.2.3",
+                "@babel/types": "^7.2.2",
+                "debug": "^4.1.0",
+                "globals": "^11.1.0",
+                "lodash": "^4.17.10"
               },
               "dependencies": {
                 "debug": {
                   "version": "4.1.1",
                   "bundled": true,
                   "requires": {
-                    "ms": "2.1.1"
+                    "ms": "^2.1.1"
                   }
                 },
                 "ms": {
@@ -1767,9 +1819,9 @@
               "version": "7.3.0",
               "bundled": true,
               "requires": {
-                "esutils": "2.0.2",
-                "lodash": "4.17.11",
-                "to-fast-properties": "2.0.0"
+                "esutils": "^2.0.2",
+                "lodash": "^4.17.10",
+                "to-fast-properties": "^2.0.0"
               }
             },
             "@types/graphql": {
@@ -1796,15 +1848,15 @@
               "version": "2.0.0",
               "bundled": true,
               "requires": {
-                "micromatch": "3.1.10",
-                "normalize-path": "2.1.1"
+                "micromatch": "^3.1.4",
+                "normalize-path": "^2.1.1"
               }
             },
             "argparse": {
               "version": "1.0.10",
               "bundled": true,
               "requires": {
-                "sprintf-js": "1.0.3"
+                "sprintf-js": "~1.0.2"
               }
             },
             "arr-diff": {
@@ -1831,7 +1883,7 @@
               "version": "1.0.2",
               "bundled": true,
               "requires": {
-                "array-uniq": "1.0.3"
+                "array-uniq": "^1.0.1"
               }
             },
             "array-uniq": {
@@ -1866,20 +1918,20 @@
               "version": "6.26.0",
               "bundled": true,
               "requires": {
-                "chalk": "1.1.3",
-                "esutils": "2.0.2",
-                "js-tokens": "3.0.2"
+                "chalk": "^1.1.3",
+                "esutils": "^2.0.2",
+                "js-tokens": "^3.0.2"
               },
               "dependencies": {
                 "chalk": {
                   "version": "1.1.3",
                   "bundled": true,
                   "requires": {
-                    "ansi-styles": "2.2.1",
-                    "escape-string-regexp": "1.0.5",
-                    "has-ansi": "2.0.0",
-                    "strip-ansi": "3.0.1",
-                    "supports-color": "2.0.0"
+                    "ansi-styles": "^2.2.1",
+                    "escape-string-regexp": "^1.0.2",
+                    "has-ansi": "^2.0.0",
+                    "strip-ansi": "^3.0.0",
+                    "supports-color": "^2.0.0"
                   }
                 }
               }
@@ -1888,7 +1940,7 @@
               "version": "2.6.2",
               "bundled": true,
               "requires": {
-                "graphql-tag": "2.10.1"
+                "graphql-tag": "^2.9.2"
               }
             },
             "balanced-match": {
@@ -1899,43 +1951,43 @@
               "version": "0.11.2",
               "bundled": true,
               "requires": {
-                "cache-base": "1.0.1",
-                "class-utils": "0.3.6",
-                "component-emitter": "1.2.1",
-                "define-property": "1.0.0",
-                "isobject": "3.0.1",
-                "mixin-deep": "1.3.1",
-                "pascalcase": "0.1.1"
+                "cache-base": "^1.0.1",
+                "class-utils": "^0.3.5",
+                "component-emitter": "^1.2.1",
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.1",
+                "mixin-deep": "^1.2.0",
+                "pascalcase": "^0.1.1"
               },
               "dependencies": {
                 "define-property": {
                   "version": "1.0.0",
                   "bundled": true,
                   "requires": {
-                    "is-descriptor": "1.0.2"
+                    "is-descriptor": "^1.0.0"
                   }
                 },
                 "is-accessor-descriptor": {
                   "version": "1.0.0",
                   "bundled": true,
                   "requires": {
-                    "kind-of": "6.0.2"
+                    "kind-of": "^6.0.0"
                   }
                 },
                 "is-data-descriptor": {
                   "version": "1.0.0",
                   "bundled": true,
                   "requires": {
-                    "kind-of": "6.0.2"
+                    "kind-of": "^6.0.0"
                   }
                 },
                 "is-descriptor": {
                   "version": "1.0.2",
                   "bundled": true,
                   "requires": {
-                    "is-accessor-descriptor": "1.0.0",
-                    "is-data-descriptor": "1.0.0",
-                    "kind-of": "6.0.2"
+                    "is-accessor-descriptor": "^1.0.0",
+                    "is-data-descriptor": "^1.0.0",
+                    "kind-of": "^6.0.2"
                   }
                 }
               }
@@ -1948,7 +2000,7 @@
               "version": "1.1.11",
               "bundled": true,
               "requires": {
-                "balanced-match": "1.0.0",
+                "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
               }
             },
@@ -1956,23 +2008,23 @@
               "version": "2.3.2",
               "bundled": true,
               "requires": {
-                "arr-flatten": "1.1.0",
-                "array-unique": "0.3.2",
-                "extend-shallow": "2.0.1",
-                "fill-range": "4.0.0",
-                "isobject": "3.0.1",
-                "repeat-element": "1.1.3",
-                "snapdragon": "0.8.2",
-                "snapdragon-node": "2.1.1",
-                "split-string": "3.1.0",
-                "to-regex": "3.0.2"
+                "arr-flatten": "^1.1.0",
+                "array-unique": "^0.3.2",
+                "extend-shallow": "^2.0.1",
+                "fill-range": "^4.0.0",
+                "isobject": "^3.0.1",
+                "repeat-element": "^1.1.2",
+                "snapdragon": "^0.8.1",
+                "snapdragon-node": "^2.0.1",
+                "split-string": "^3.0.2",
+                "to-regex": "^3.0.1"
               },
               "dependencies": {
                 "extend-shallow": {
                   "version": "2.0.1",
                   "bundled": true,
                   "requires": {
-                    "is-extendable": "0.1.1"
+                    "is-extendable": "^0.1.0"
                   }
                 }
               }
@@ -1981,9 +2033,9 @@
               "version": "4.4.1",
               "bundled": true,
               "requires": {
-                "caniuse-lite": "1.0.30000929",
-                "electron-to-chromium": "1.3.103",
-                "node-releases": "1.1.3"
+                "caniuse-lite": "^1.0.30000929",
+                "electron-to-chromium": "^1.3.103",
+                "node-releases": "^1.1.3"
               }
             },
             "builtin-modules": {
@@ -1994,15 +2046,15 @@
               "version": "1.0.1",
               "bundled": true,
               "requires": {
-                "collection-visit": "1.0.0",
-                "component-emitter": "1.2.1",
-                "get-value": "2.0.6",
-                "has-value": "1.0.0",
-                "isobject": "3.0.1",
-                "set-value": "2.0.0",
-                "to-object-path": "0.3.0",
-                "union-value": "1.0.0",
-                "unset-value": "1.0.0"
+                "collection-visit": "^1.0.0",
+                "component-emitter": "^1.2.1",
+                "get-value": "^2.0.6",
+                "has-value": "^1.0.0",
+                "isobject": "^3.0.1",
+                "set-value": "^2.0.0",
+                "to-object-path": "^0.3.0",
+                "union-value": "^1.0.0",
+                "unset-value": "^1.0.0"
               }
             },
             "camelcase": {
@@ -2013,8 +2065,8 @@
               "version": "2.1.0",
               "bundled": true,
               "requires": {
-                "camelcase": "2.1.1",
-                "map-obj": "1.0.1"
+                "camelcase": "^2.0.0",
+                "map-obj": "^1.0.0"
               }
             },
             "caniuse-lite": {
@@ -2025,23 +2077,23 @@
               "version": "2.4.2",
               "bundled": true,
               "requires": {
-                "ansi-styles": "3.2.1",
-                "escape-string-regexp": "1.0.5",
-                "supports-color": "5.5.0"
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
               },
               "dependencies": {
                 "ansi-styles": {
                   "version": "3.2.1",
                   "bundled": true,
                   "requires": {
-                    "color-convert": "1.9.3"
+                    "color-convert": "^1.9.0"
                   }
                 },
                 "supports-color": {
                   "version": "5.5.0",
                   "bundled": true,
                   "requires": {
-                    "has-flag": "3.0.0"
+                    "has-flag": "^3.0.0"
                   }
                 }
               }
@@ -2050,35 +2102,35 @@
               "version": "2.0.4",
               "bundled": true,
               "requires": {
-                "anymatch": "2.0.0",
-                "async-each": "1.0.1",
-                "braces": "2.3.2",
-                "glob-parent": "3.1.0",
-                "inherits": "2.0.3",
-                "is-binary-path": "1.0.1",
-                "is-glob": "4.0.0",
-                "lodash.debounce": "4.0.8",
-                "normalize-path": "2.1.1",
-                "path-is-absolute": "1.0.1",
-                "readdirp": "2.2.1",
-                "upath": "1.1.0"
+                "anymatch": "^2.0.0",
+                "async-each": "^1.0.0",
+                "braces": "^2.3.0",
+                "glob-parent": "^3.1.0",
+                "inherits": "^2.0.1",
+                "is-binary-path": "^1.0.0",
+                "is-glob": "^4.0.0",
+                "lodash.debounce": "^4.0.8",
+                "normalize-path": "^2.1.1",
+                "path-is-absolute": "^1.0.0",
+                "readdirp": "^2.0.0",
+                "upath": "^1.0.5"
               }
             },
             "class-utils": {
               "version": "0.3.6",
               "bundled": true,
               "requires": {
-                "arr-union": "3.1.0",
-                "define-property": "0.2.5",
-                "isobject": "3.0.1",
-                "static-extend": "0.1.2"
+                "arr-union": "^3.1.0",
+                "define-property": "^0.2.5",
+                "isobject": "^3.0.0",
+                "static-extend": "^0.1.1"
               },
               "dependencies": {
                 "define-property": {
                   "version": "0.2.5",
                   "bundled": true,
                   "requires": {
-                    "is-descriptor": "0.1.6"
+                    "is-descriptor": "^0.1.0"
                   }
                 }
               }
@@ -2087,18 +2139,18 @@
               "version": "0.5.1",
               "bundled": true,
               "requires": {
-                "colors": "1.1.2",
-                "object-assign": "4.1.1",
-                "string-width": "2.1.1"
+                "colors": "^1.1.2",
+                "object-assign": "^4.1.0",
+                "string-width": "^2.1.1"
               }
             },
             "cliui": {
               "version": "4.1.0",
               "bundled": true,
               "requires": {
-                "string-width": "2.1.1",
-                "strip-ansi": "4.0.0",
-                "wrap-ansi": "2.1.0"
+                "string-width": "^2.1.1",
+                "strip-ansi": "^4.0.0",
+                "wrap-ansi": "^2.0.0"
               },
               "dependencies": {
                 "ansi-regex": {
@@ -2109,7 +2161,7 @@
                   "version": "4.0.0",
                   "bundled": true,
                   "requires": {
-                    "ansi-regex": "3.0.0"
+                    "ansi-regex": "^3.0.0"
                   }
                 }
               }
@@ -2126,8 +2178,8 @@
               "version": "1.0.0",
               "bundled": true,
               "requires": {
-                "map-visit": "1.0.0",
-                "object-visit": "1.0.1"
+                "map-visit": "^1.0.0",
+                "object-visit": "^1.0.0"
               }
             },
             "color-convert": {
@@ -2161,7 +2213,7 @@
               "version": "1.6.0",
               "bundled": true,
               "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "~5.1.1"
               }
             },
             "copy-descriptor": {
@@ -2176,19 +2228,19 @@
               "version": "5.1.0",
               "bundled": true,
               "requires": {
-                "lru-cache": "4.1.5",
-                "shebang-command": "1.2.0",
-                "which": "1.3.1"
+                "lru-cache": "^4.0.1",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
               }
             },
             "csproj2ts": {
               "version": "1.1.0",
               "bundled": true,
               "requires": {
-                "es6-promise": "4.2.5",
-                "lodash": "4.17.11",
-                "semver": "5.6.0",
-                "xml2js": "0.4.19"
+                "es6-promise": "^4.1.1",
+                "lodash": "^4.17.4",
+                "semver": "^5.4.1",
+                "xml2js": "^0.4.19"
               },
               "dependencies": {
                 "es6-promise": {
@@ -2201,15 +2253,15 @@
               "version": "0.4.1",
               "bundled": true,
               "requires": {
-                "array-find-index": "1.0.2"
+                "array-find-index": "^1.0.1"
               }
             },
             "dateformat": {
               "version": "1.0.12",
               "bundled": true,
               "requires": {
-                "get-stdin": "4.0.1",
-                "meow": "3.7.0"
+                "get-stdin": "^4.0.1",
+                "meow": "^3.3.0"
               }
             },
             "debug": {
@@ -2231,31 +2283,31 @@
               "version": "2.0.2",
               "bundled": true,
               "requires": {
-                "is-descriptor": "1.0.2",
-                "isobject": "3.0.1"
+                "is-descriptor": "^1.0.2",
+                "isobject": "^3.0.1"
               },
               "dependencies": {
                 "is-accessor-descriptor": {
                   "version": "1.0.0",
                   "bundled": true,
                   "requires": {
-                    "kind-of": "6.0.2"
+                    "kind-of": "^6.0.0"
                   }
                 },
                 "is-data-descriptor": {
                   "version": "1.0.0",
                   "bundled": true,
                   "requires": {
-                    "kind-of": "6.0.2"
+                    "kind-of": "^6.0.0"
                   }
                 },
                 "is-descriptor": {
                   "version": "1.0.2",
                   "bundled": true,
                   "requires": {
-                    "is-accessor-descriptor": "1.0.0",
-                    "is-data-descriptor": "1.0.0",
-                    "kind-of": "6.0.2"
+                    "is-accessor-descriptor": "^1.0.0",
+                    "is-data-descriptor": "^1.0.0",
+                    "kind-of": "^6.0.2"
                   }
                 }
               }
@@ -2264,7 +2316,7 @@
               "version": "4.0.0",
               "bundled": true,
               "requires": {
-                "repeating": "2.0.1"
+                "repeating": "^2.0.0"
               }
             },
             "detect-newline": {
@@ -2283,7 +2335,7 @@
               "version": "1.3.2",
               "bundled": true,
               "requires": {
-                "is-arrayish": "0.2.1"
+                "is-arrayish": "^0.2.1"
               }
             },
             "es6-promise": {
@@ -2310,13 +2362,13 @@
               "version": "0.7.0",
               "bundled": true,
               "requires": {
-                "cross-spawn": "5.1.0",
-                "get-stream": "3.0.0",
-                "is-stream": "1.1.0",
-                "npm-run-path": "2.0.2",
-                "p-finally": "1.0.0",
-                "signal-exit": "3.0.2",
-                "strip-eof": "1.0.0"
+                "cross-spawn": "^5.0.1",
+                "get-stream": "^3.0.0",
+                "is-stream": "^1.1.0",
+                "npm-run-path": "^2.0.0",
+                "p-finally": "^1.0.0",
+                "signal-exit": "^3.0.0",
+                "strip-eof": "^1.0.0"
               }
             },
             "exit": {
@@ -2327,27 +2379,27 @@
               "version": "2.1.4",
               "bundled": true,
               "requires": {
-                "debug": "2.6.9",
-                "define-property": "0.2.5",
-                "extend-shallow": "2.0.1",
-                "posix-character-classes": "0.1.1",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "debug": "^2.3.3",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "posix-character-classes": "^0.1.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
               },
               "dependencies": {
                 "define-property": {
                   "version": "0.2.5",
                   "bundled": true,
                   "requires": {
-                    "is-descriptor": "0.1.6"
+                    "is-descriptor": "^0.1.0"
                   }
                 },
                 "extend-shallow": {
                   "version": "2.0.1",
                   "bundled": true,
                   "requires": {
-                    "is-extendable": "0.1.1"
+                    "is-extendable": "^0.1.0"
                   }
                 }
               }
@@ -2356,15 +2408,15 @@
               "version": "3.0.2",
               "bundled": true,
               "requires": {
-                "assign-symbols": "1.0.0",
-                "is-extendable": "1.0.1"
+                "assign-symbols": "^1.0.0",
+                "is-extendable": "^1.0.1"
               },
               "dependencies": {
                 "is-extendable": {
                   "version": "1.0.1",
                   "bundled": true,
                   "requires": {
-                    "is-plain-object": "2.0.4"
+                    "is-plain-object": "^2.0.4"
                   }
                 }
               }
@@ -2373,51 +2425,51 @@
               "version": "2.0.4",
               "bundled": true,
               "requires": {
-                "array-unique": "0.3.2",
-                "define-property": "1.0.0",
-                "expand-brackets": "2.1.4",
-                "extend-shallow": "2.0.1",
-                "fragment-cache": "0.2.1",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "array-unique": "^0.3.2",
+                "define-property": "^1.0.0",
+                "expand-brackets": "^2.1.4",
+                "extend-shallow": "^2.0.1",
+                "fragment-cache": "^0.2.1",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
               },
               "dependencies": {
                 "define-property": {
                   "version": "1.0.0",
                   "bundled": true,
                   "requires": {
-                    "is-descriptor": "1.0.2"
+                    "is-descriptor": "^1.0.0"
                   }
                 },
                 "extend-shallow": {
                   "version": "2.0.1",
                   "bundled": true,
                   "requires": {
-                    "is-extendable": "0.1.1"
+                    "is-extendable": "^0.1.0"
                   }
                 },
                 "is-accessor-descriptor": {
                   "version": "1.0.0",
                   "bundled": true,
                   "requires": {
-                    "kind-of": "6.0.2"
+                    "kind-of": "^6.0.0"
                   }
                 },
                 "is-data-descriptor": {
                   "version": "1.0.0",
                   "bundled": true,
                   "requires": {
-                    "kind-of": "6.0.2"
+                    "kind-of": "^6.0.0"
                   }
                 },
                 "is-descriptor": {
                   "version": "1.0.2",
                   "bundled": true,
                   "requires": {
-                    "is-accessor-descriptor": "1.0.0",
-                    "is-data-descriptor": "1.0.0",
-                    "kind-of": "6.0.2"
+                    "is-accessor-descriptor": "^1.0.0",
+                    "is-data-descriptor": "^1.0.0",
+                    "kind-of": "^6.0.2"
                   }
                 }
               }
@@ -2430,17 +2482,17 @@
               "version": "4.0.0",
               "bundled": true,
               "requires": {
-                "extend-shallow": "2.0.1",
-                "is-number": "3.0.0",
-                "repeat-string": "1.6.1",
-                "to-regex-range": "2.1.1"
+                "extend-shallow": "^2.0.1",
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1",
+                "to-regex-range": "^2.1.0"
               },
               "dependencies": {
                 "extend-shallow": {
                   "version": "2.0.1",
                   "bundled": true,
                   "requires": {
-                    "is-extendable": "0.1.1"
+                    "is-extendable": "^0.1.0"
                   }
                 }
               }
@@ -2449,26 +2501,26 @@
               "version": "1.1.2",
               "bundled": true,
               "requires": {
-                "path-exists": "2.1.0",
-                "pinkie-promise": "2.0.1"
+                "path-exists": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
               }
             },
             "findup-sync": {
               "version": "0.3.0",
               "bundled": true,
               "requires": {
-                "glob": "5.0.15"
+                "glob": "~5.0.0"
               },
               "dependencies": {
                 "glob": {
                   "version": "5.0.15",
                   "bundled": true,
                   "requires": {
-                    "inflight": "1.0.6",
-                    "inherits": "2.0.3",
-                    "minimatch": "3.0.4",
-                    "once": "1.4.0",
-                    "path-is-absolute": "1.0.1"
+                    "inflight": "^1.0.4",
+                    "inherits": "2",
+                    "minimatch": "2 || 3",
+                    "once": "^1.3.0",
+                    "path-is-absolute": "^1.0.0"
                   }
                 }
               }
@@ -2481,7 +2533,7 @@
               "version": "0.2.1",
               "bundled": true,
               "requires": {
-                "map-cache": "0.2.2"
+                "map-cache": "^0.2.2"
               }
             },
             "fs-readdir-recursive": {
@@ -2516,27 +2568,27 @@
               "version": "7.1.3",
               "bundled": true,
               "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
               }
             },
             "glob-parent": {
               "version": "3.1.0",
               "bundled": true,
               "requires": {
-                "is-glob": "3.1.0",
-                "path-dirname": "1.0.2"
+                "is-glob": "^3.1.0",
+                "path-dirname": "^1.0.0"
               },
               "dependencies": {
                 "is-glob": {
                   "version": "3.1.0",
                   "bundled": true,
                   "requires": {
-                    "is-extglob": "2.1.1"
+                    "is-extglob": "^2.1.0"
                   }
                 }
               }
@@ -2553,7 +2605,7 @@
               "version": "14.1.1",
               "bundled": true,
               "requires": {
-                "iterall": "1.2.2"
+                "iterall": "^1.2.2"
               }
             },
             "graphql-tag": {
@@ -2564,23 +2616,23 @@
               "version": "1.0.3",
               "bundled": true,
               "requires": {
-                "coffeescript": "1.10.0",
-                "dateformat": "1.0.12",
-                "eventemitter2": "0.4.14",
-                "exit": "0.1.2",
-                "findup-sync": "0.3.0",
-                "glob": "7.0.6",
-                "grunt-cli": "1.2.0",
-                "grunt-known-options": "1.1.1",
-                "grunt-legacy-log": "2.0.0",
-                "grunt-legacy-util": "1.1.1",
-                "iconv-lite": "0.4.24",
-                "js-yaml": "3.5.5",
-                "minimatch": "3.0.4",
-                "mkdirp": "0.5.1",
-                "nopt": "3.0.6",
-                "path-is-absolute": "1.0.1",
-                "rimraf": "2.6.3"
+                "coffeescript": "~1.10.0",
+                "dateformat": "~1.0.12",
+                "eventemitter2": "~0.4.13",
+                "exit": "~0.1.1",
+                "findup-sync": "~0.3.0",
+                "glob": "~7.0.0",
+                "grunt-cli": "~1.2.0",
+                "grunt-known-options": "~1.1.0",
+                "grunt-legacy-log": "~2.0.0",
+                "grunt-legacy-util": "~1.1.1",
+                "iconv-lite": "~0.4.13",
+                "js-yaml": "~3.5.2",
+                "minimatch": "~3.0.2",
+                "mkdirp": "~0.5.1",
+                "nopt": "~3.0.6",
+                "path-is-absolute": "~1.0.0",
+                "rimraf": "~2.6.2"
               },
               "dependencies": {
                 "esprima": {
@@ -2591,30 +2643,30 @@
                   "version": "7.0.6",
                   "bundled": true,
                   "requires": {
-                    "fs.realpath": "1.0.0",
-                    "inflight": "1.0.6",
-                    "inherits": "2.0.3",
-                    "minimatch": "3.0.4",
-                    "once": "1.4.0",
-                    "path-is-absolute": "1.0.1"
+                    "fs.realpath": "^1.0.0",
+                    "inflight": "^1.0.4",
+                    "inherits": "2",
+                    "minimatch": "^3.0.2",
+                    "once": "^1.3.0",
+                    "path-is-absolute": "^1.0.0"
                   }
                 },
                 "grunt-cli": {
                   "version": "1.2.0",
                   "bundled": true,
                   "requires": {
-                    "findup-sync": "0.3.0",
-                    "grunt-known-options": "1.1.1",
-                    "nopt": "3.0.6",
-                    "resolve": "1.1.7"
+                    "findup-sync": "~0.3.0",
+                    "grunt-known-options": "~1.1.0",
+                    "nopt": "~3.0.6",
+                    "resolve": "~1.1.0"
                   }
                 },
                 "js-yaml": {
                   "version": "3.5.5",
                   "bundled": true,
                   "requires": {
-                    "argparse": "1.0.10",
-                    "esprima": "2.7.3"
+                    "argparse": "^1.0.2",
+                    "esprima": "^2.6.0"
                   }
                 },
                 "resolve": {
@@ -2631,15 +2683,15 @@
               "version": "2.0.0",
               "bundled": true,
               "requires": {
-                "async": "2.6.1",
-                "rimraf": "2.6.3"
+                "async": "^2.6.1",
+                "rimraf": "^2.6.2"
               },
               "dependencies": {
                 "async": {
                   "version": "2.6.1",
                   "bundled": true,
                   "requires": {
-                    "lodash": "4.17.11"
+                    "lodash": "^4.17.10"
                   }
                 }
               }
@@ -2648,19 +2700,19 @@
               "version": "1.0.0",
               "bundled": true,
               "requires": {
-                "chalk": "1.1.3",
-                "file-sync-cmp": "0.1.1"
+                "chalk": "^1.1.1",
+                "file-sync-cmp": "^0.1.0"
               },
               "dependencies": {
                 "chalk": {
                   "version": "1.1.3",
                   "bundled": true,
                   "requires": {
-                    "ansi-styles": "2.2.1",
-                    "escape-string-regexp": "1.0.5",
-                    "has-ansi": "2.0.0",
-                    "strip-ansi": "3.0.1",
-                    "supports-color": "2.0.0"
+                    "ansi-styles": "^2.2.1",
+                    "escape-string-regexp": "^1.0.2",
+                    "has-ansi": "^2.0.0",
+                    "strip-ansi": "^3.0.0",
+                    "supports-color": "^2.0.0"
                   }
                 }
               }
@@ -2673,48 +2725,48 @@
               "version": "2.0.0",
               "bundled": true,
               "requires": {
-                "colors": "1.1.2",
-                "grunt-legacy-log-utils": "2.0.1",
-                "hooker": "0.2.3",
-                "lodash": "4.17.11"
+                "colors": "~1.1.2",
+                "grunt-legacy-log-utils": "~2.0.0",
+                "hooker": "~0.2.3",
+                "lodash": "~4.17.5"
               }
             },
             "grunt-legacy-log-utils": {
               "version": "2.0.1",
               "bundled": true,
               "requires": {
-                "chalk": "2.4.2",
-                "lodash": "4.17.11"
+                "chalk": "~2.4.1",
+                "lodash": "~4.17.10"
               }
             },
             "grunt-legacy-util": {
               "version": "1.1.1",
               "bundled": true,
               "requires": {
-                "async": "1.5.2",
-                "exit": "0.1.2",
-                "getobject": "0.1.0",
-                "hooker": "0.2.3",
-                "lodash": "4.17.11",
-                "underscore.string": "3.3.5",
-                "which": "1.3.1"
+                "async": "~1.5.2",
+                "exit": "~0.1.1",
+                "getobject": "~0.1.0",
+                "hooker": "~0.2.3",
+                "lodash": "~4.17.10",
+                "underscore.string": "~3.3.4",
+                "which": "~1.3.0"
               }
             },
             "grunt-ts": {
               "version": "6.0.0-beta.22",
               "bundled": true,
               "requires": {
-                "chokidar": "2.0.4",
-                "csproj2ts": "1.1.0",
-                "detect-indent": "4.0.0",
-                "detect-newline": "2.1.0",
-                "es6-promise": "0.1.2",
-                "jsmin2": "1.2.1",
-                "lodash": "4.17.11",
+                "chokidar": "^2.0.4",
+                "csproj2ts": "^1.1.0",
+                "detect-indent": "^4.0.0",
+                "detect-newline": "^2.1.0",
+                "es6-promise": "~0.1.1",
+                "jsmin2": "^1.2.1",
+                "lodash": "~4.17.10",
                 "ncp": "0.5.1",
                 "rimraf": "2.2.6",
-                "semver": "5.6.0",
-                "strip-bom": "2.0.0"
+                "semver": "^5.3.0",
+                "strip-bom": "^2.0.0"
               },
               "dependencies": {
                 "rimraf": {
@@ -2731,7 +2783,7 @@
               "version": "2.0.0",
               "bundled": true,
               "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
               }
             },
             "has-flag": {
@@ -2742,24 +2794,24 @@
               "version": "1.0.0",
               "bundled": true,
               "requires": {
-                "get-value": "2.0.6",
-                "has-values": "1.0.0",
-                "isobject": "3.0.1"
+                "get-value": "^2.0.6",
+                "has-values": "^1.0.0",
+                "isobject": "^3.0.0"
               }
             },
             "has-values": {
               "version": "1.0.0",
               "bundled": true,
               "requires": {
-                "is-number": "3.0.0",
-                "kind-of": "4.0.0"
+                "is-number": "^3.0.0",
+                "kind-of": "^4.0.0"
               },
               "dependencies": {
                 "kind-of": {
                   "version": "4.0.0",
                   "bundled": true,
                   "requires": {
-                    "is-buffer": "1.1.6"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -2776,22 +2828,22 @@
               "version": "0.4.24",
               "bundled": true,
               "requires": {
-                "safer-buffer": "2.1.2"
+                "safer-buffer": ">= 2.1.2 < 3"
               }
             },
             "indent-string": {
               "version": "2.1.0",
               "bundled": true,
               "requires": {
-                "repeating": "2.0.1"
+                "repeating": "^2.0.0"
               }
             },
             "inflight": {
               "version": "1.0.6",
               "bundled": true,
               "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
               }
             },
             "inherits": {
@@ -2802,7 +2854,7 @@
               "version": "2.2.4",
               "bundled": true,
               "requires": {
-                "loose-envify": "1.4.0"
+                "loose-envify": "^1.0.0"
               }
             },
             "invert-kv": {
@@ -2813,14 +2865,14 @@
               "version": "0.1.6",
               "bundled": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
                   "bundled": true,
                   "requires": {
-                    "is-buffer": "1.1.6"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -2833,7 +2885,7 @@
               "version": "1.0.1",
               "bundled": true,
               "requires": {
-                "binary-extensions": "1.12.0"
+                "binary-extensions": "^1.0.0"
               }
             },
             "is-buffer": {
@@ -2844,21 +2896,21 @@
               "version": "1.0.0",
               "bundled": true,
               "requires": {
-                "builtin-modules": "1.1.1"
+                "builtin-modules": "^1.0.0"
               }
             },
             "is-data-descriptor": {
               "version": "0.1.4",
               "bundled": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
                   "bundled": true,
                   "requires": {
-                    "is-buffer": "1.1.6"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -2867,9 +2919,9 @@
               "version": "0.1.6",
               "bundled": true,
               "requires": {
-                "is-accessor-descriptor": "0.1.6",
-                "is-data-descriptor": "0.1.4",
-                "kind-of": "5.1.0"
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
               },
               "dependencies": {
                 "kind-of": {
@@ -2890,7 +2942,7 @@
               "version": "1.0.2",
               "bundled": true,
               "requires": {
-                "number-is-nan": "1.0.1"
+                "number-is-nan": "^1.0.0"
               }
             },
             "is-fullwidth-code-point": {
@@ -2901,21 +2953,21 @@
               "version": "4.0.0",
               "bundled": true,
               "requires": {
-                "is-extglob": "2.1.1"
+                "is-extglob": "^2.1.1"
               }
             },
             "is-number": {
               "version": "3.0.0",
               "bundled": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
                   "bundled": true,
                   "requires": {
-                    "is-buffer": "1.1.6"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -2928,7 +2980,7 @@
               "version": "2.0.4",
               "bundled": true,
               "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.1"
               }
             },
             "is-stream": {
@@ -2971,8 +3023,8 @@
               "version": "3.12.1",
               "bundled": true,
               "requires": {
-                "argparse": "1.0.10",
-                "esprima": "4.0.1"
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
               }
             },
             "jsesc": {
@@ -2987,7 +3039,7 @@
               "version": "2.1.0",
               "bundled": true,
               "requires": {
-                "minimist": "1.2.0"
+                "minimist": "^1.2.0"
               }
             },
             "kind-of": {
@@ -2998,36 +3050,36 @@
               "version": "1.0.0",
               "bundled": true,
               "requires": {
-                "invert-kv": "1.0.0"
+                "invert-kv": "^1.0.0"
               }
             },
             "load-grunt-tasks": {
               "version": "4.0.0",
               "bundled": true,
               "requires": {
-                "arrify": "1.0.1",
-                "multimatch": "2.1.0",
-                "pkg-up": "2.0.0",
-                "resolve-pkg": "1.0.0"
+                "arrify": "^1.0.0",
+                "multimatch": "^2.0.0",
+                "pkg-up": "^2.0.0",
+                "resolve-pkg": "^1.0.0"
               }
             },
             "load-json-file": {
               "version": "1.1.0",
               "bundled": true,
               "requires": {
-                "graceful-fs": "4.1.15",
-                "parse-json": "2.2.0",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1",
-                "strip-bom": "2.0.0"
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^2.2.0",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0",
+                "strip-bom": "^2.0.0"
               }
             },
             "locate-path": {
               "version": "2.0.0",
               "bundled": true,
               "requires": {
-                "p-locate": "2.0.0",
-                "path-exists": "3.0.0"
+                "p-locate": "^2.0.0",
+                "path-exists": "^3.0.0"
               },
               "dependencies": {
                 "path-exists": {
@@ -3048,23 +3100,23 @@
               "version": "1.4.0",
               "bundled": true,
               "requires": {
-                "js-tokens": "3.0.2"
+                "js-tokens": "^3.0.0 || ^4.0.0"
               }
             },
             "loud-rejection": {
               "version": "1.6.0",
               "bundled": true,
               "requires": {
-                "currently-unhandled": "0.4.1",
-                "signal-exit": "3.0.2"
+                "currently-unhandled": "^0.4.1",
+                "signal-exit": "^3.0.0"
               }
             },
             "lru-cache": {
               "version": "4.1.5",
               "bundled": true,
               "requires": {
-                "pseudomap": "1.0.2",
-                "yallist": "2.1.2"
+                "pseudomap": "^1.0.2",
+                "yallist": "^2.1.2"
               }
             },
             "map-cache": {
@@ -3079,49 +3131,49 @@
               "version": "1.0.0",
               "bundled": true,
               "requires": {
-                "object-visit": "1.0.1"
+                "object-visit": "^1.0.0"
               }
             },
             "mem": {
               "version": "1.1.0",
               "bundled": true,
               "requires": {
-                "mimic-fn": "1.2.0"
+                "mimic-fn": "^1.0.0"
               }
             },
             "meow": {
               "version": "3.7.0",
               "bundled": true,
               "requires": {
-                "camelcase-keys": "2.1.0",
-                "decamelize": "1.2.0",
-                "loud-rejection": "1.6.0",
-                "map-obj": "1.0.1",
-                "minimist": "1.2.0",
-                "normalize-package-data": "2.4.0",
-                "object-assign": "4.1.1",
-                "read-pkg-up": "1.0.1",
-                "redent": "1.0.0",
-                "trim-newlines": "1.0.0"
+                "camelcase-keys": "^2.0.0",
+                "decamelize": "^1.1.2",
+                "loud-rejection": "^1.0.0",
+                "map-obj": "^1.0.1",
+                "minimist": "^1.1.3",
+                "normalize-package-data": "^2.3.4",
+                "object-assign": "^4.0.1",
+                "read-pkg-up": "^1.0.1",
+                "redent": "^1.0.0",
+                "trim-newlines": "^1.0.0"
               }
             },
             "micromatch": {
               "version": "3.1.10",
               "bundled": true,
               "requires": {
-                "arr-diff": "4.0.0",
-                "array-unique": "0.3.2",
-                "braces": "2.3.2",
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "extglob": "2.0.4",
-                "fragment-cache": "0.2.1",
-                "kind-of": "6.0.2",
-                "nanomatch": "1.2.13",
-                "object.pick": "1.3.0",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "braces": "^2.3.1",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "extglob": "^2.0.4",
+                "fragment-cache": "^0.2.1",
+                "kind-of": "^6.0.2",
+                "nanomatch": "^1.2.9",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.2"
               }
             },
             "mimic-fn": {
@@ -3132,7 +3184,7 @@
               "version": "3.0.4",
               "bundled": true,
               "requires": {
-                "brace-expansion": "1.1.11"
+                "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
@@ -3143,15 +3195,15 @@
               "version": "1.3.1",
               "bundled": true,
               "requires": {
-                "for-in": "1.0.2",
-                "is-extendable": "1.0.1"
+                "for-in": "^1.0.2",
+                "is-extendable": "^1.0.1"
               },
               "dependencies": {
                 "is-extendable": {
                   "version": "1.0.1",
                   "bundled": true,
                   "requires": {
-                    "is-plain-object": "2.0.4"
+                    "is-plain-object": "^2.0.4"
                   }
                 }
               }
@@ -3177,27 +3229,27 @@
               "version": "2.1.0",
               "bundled": true,
               "requires": {
-                "array-differ": "1.0.0",
-                "array-union": "1.0.2",
-                "arrify": "1.0.1",
-                "minimatch": "3.0.4"
+                "array-differ": "^1.0.0",
+                "array-union": "^1.0.1",
+                "arrify": "^1.0.0",
+                "minimatch": "^3.0.0"
               }
             },
             "nanomatch": {
               "version": "1.2.13",
               "bundled": true,
               "requires": {
-                "arr-diff": "4.0.0",
-                "array-unique": "0.3.2",
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "fragment-cache": "0.2.1",
-                "is-windows": "1.0.2",
-                "kind-of": "6.0.2",
-                "object.pick": "1.3.0",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "fragment-cache": "^0.2.1",
+                "is-windows": "^1.0.2",
+                "kind-of": "^6.0.2",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
               }
             },
             "ncp": {
@@ -3208,38 +3260,38 @@
               "version": "1.1.3",
               "bundled": true,
               "requires": {
-                "semver": "5.6.0"
+                "semver": "^5.3.0"
               }
             },
             "nopt": {
               "version": "3.0.6",
               "bundled": true,
               "requires": {
-                "abbrev": "1.1.1"
+                "abbrev": "1"
               }
             },
             "normalize-package-data": {
               "version": "2.4.0",
               "bundled": true,
               "requires": {
-                "hosted-git-info": "2.7.1",
-                "is-builtin-module": "1.0.0",
-                "semver": "5.6.0",
-                "validate-npm-package-license": "3.0.4"
+                "hosted-git-info": "^2.1.4",
+                "is-builtin-module": "^1.0.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
               }
             },
             "normalize-path": {
               "version": "2.1.1",
               "bundled": true,
               "requires": {
-                "remove-trailing-separator": "1.1.0"
+                "remove-trailing-separator": "^1.0.1"
               }
             },
             "npm-run-path": {
               "version": "2.0.2",
               "bundled": true,
               "requires": {
-                "path-key": "2.0.1"
+                "path-key": "^2.0.0"
               }
             },
             "number-is-nan": {
@@ -3254,23 +3306,23 @@
               "version": "0.1.0",
               "bundled": true,
               "requires": {
-                "copy-descriptor": "0.1.1",
-                "define-property": "0.2.5",
-                "kind-of": "3.2.2"
+                "copy-descriptor": "^0.1.0",
+                "define-property": "^0.2.5",
+                "kind-of": "^3.0.3"
               },
               "dependencies": {
                 "define-property": {
                   "version": "0.2.5",
                   "bundled": true,
                   "requires": {
-                    "is-descriptor": "0.1.6"
+                    "is-descriptor": "^0.1.0"
                   }
                 },
                 "kind-of": {
                   "version": "3.2.2",
                   "bundled": true,
                   "requires": {
-                    "is-buffer": "1.1.6"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -3279,39 +3331,39 @@
               "version": "1.0.1",
               "bundled": true,
               "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.0"
               }
             },
             "object.pick": {
               "version": "1.3.0",
               "bundled": true,
               "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.1"
               }
             },
             "once": {
               "version": "1.4.0",
               "bundled": true,
               "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
               }
             },
             "os-locale": {
               "version": "2.1.0",
               "bundled": true,
               "requires": {
-                "execa": "0.7.0",
-                "lcid": "1.0.0",
-                "mem": "1.1.0"
+                "execa": "^0.7.0",
+                "lcid": "^1.0.0",
+                "mem": "^1.1.0"
               }
             },
             "output-file-sync": {
               "version": "2.0.1",
               "bundled": true,
               "requires": {
-                "graceful-fs": "4.1.15",
-                "is-plain-obj": "1.1.0",
-                "mkdirp": "0.5.1"
+                "graceful-fs": "^4.1.11",
+                "is-plain-obj": "^1.1.0",
+                "mkdirp": "^0.5.1"
               }
             },
             "p-finally": {
@@ -3322,14 +3374,14 @@
               "version": "1.3.0",
               "bundled": true,
               "requires": {
-                "p-try": "1.0.0"
+                "p-try": "^1.0.0"
               }
             },
             "p-locate": {
               "version": "2.0.0",
               "bundled": true,
               "requires": {
-                "p-limit": "1.3.0"
+                "p-limit": "^1.1.0"
               }
             },
             "p-try": {
@@ -3340,7 +3392,7 @@
               "version": "2.2.0",
               "bundled": true,
               "requires": {
-                "error-ex": "1.3.2"
+                "error-ex": "^1.2.0"
               }
             },
             "pascalcase": {
@@ -3355,7 +3407,7 @@
               "version": "2.1.0",
               "bundled": true,
               "requires": {
-                "pinkie-promise": "2.0.1"
+                "pinkie-promise": "^2.0.0"
               }
             },
             "path-is-absolute": {
@@ -3374,9 +3426,9 @@
               "version": "1.1.0",
               "bundled": true,
               "requires": {
-                "graceful-fs": "4.1.15",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1"
+                "graceful-fs": "^4.1.2",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0"
               }
             },
             "pify": {
@@ -3391,21 +3443,21 @@
               "version": "2.0.1",
               "bundled": true,
               "requires": {
-                "pinkie": "2.0.4"
+                "pinkie": "^2.0.0"
               }
             },
             "pkg-up": {
               "version": "2.0.0",
               "bundled": true,
               "requires": {
-                "find-up": "2.1.0"
+                "find-up": "^2.1.0"
               },
               "dependencies": {
                 "find-up": {
                   "version": "2.1.0",
                   "bundled": true,
                   "requires": {
-                    "locate-path": "2.0.0"
+                    "locate-path": "^2.0.0"
                   }
                 }
               }
@@ -3430,47 +3482,47 @@
               "version": "1.1.0",
               "bundled": true,
               "requires": {
-                "load-json-file": "1.1.0",
-                "normalize-package-data": "2.4.0",
-                "path-type": "1.1.0"
+                "load-json-file": "^1.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^1.0.0"
               }
             },
             "read-pkg-up": {
               "version": "1.0.1",
               "bundled": true,
               "requires": {
-                "find-up": "1.1.2",
-                "read-pkg": "1.1.0"
+                "find-up": "^1.0.0",
+                "read-pkg": "^1.0.0"
               }
             },
             "readable-stream": {
               "version": "2.3.6",
               "bundled": true,
               "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "2.0.0",
-                "safe-buffer": "5.1.2",
-                "string_decoder": "1.1.1",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
               }
             },
             "readdirp": {
               "version": "2.2.1",
               "bundled": true,
               "requires": {
-                "graceful-fs": "4.1.15",
-                "micromatch": "3.1.10",
-                "readable-stream": "2.3.6"
+                "graceful-fs": "^4.1.11",
+                "micromatch": "^3.1.10",
+                "readable-stream": "^2.0.2"
               }
             },
             "redent": {
               "version": "1.0.0",
               "bundled": true,
               "requires": {
-                "indent-string": "2.1.0",
-                "strip-indent": "1.0.1"
+                "indent-string": "^2.1.0",
+                "strip-indent": "^1.0.1"
               }
             },
             "regenerate": {
@@ -3481,43 +3533,43 @@
               "version": "7.0.0",
               "bundled": true,
               "requires": {
-                "regenerate": "1.4.0"
+                "regenerate": "^1.4.0"
               }
             },
             "regenerator-transform": {
               "version": "0.13.3",
               "bundled": true,
               "requires": {
-                "private": "0.1.8"
+                "private": "^0.1.6"
               }
             },
             "regex-not": {
               "version": "1.0.2",
               "bundled": true,
               "requires": {
-                "extend-shallow": "3.0.2",
-                "safe-regex": "1.1.0"
+                "extend-shallow": "^3.0.2",
+                "safe-regex": "^1.1.0"
               }
             },
             "regexp-tree": {
               "version": "0.1.0",
               "bundled": true,
               "requires": {
-                "cli-table3": "0.5.1",
-                "colors": "1.1.2",
-                "yargs": "10.1.2"
+                "cli-table3": "^0.5.0",
+                "colors": "^1.1.2",
+                "yargs": "^10.0.3"
               }
             },
             "regexpu-core": {
               "version": "4.4.0",
               "bundled": true,
               "requires": {
-                "regenerate": "1.4.0",
-                "regenerate-unicode-properties": "7.0.0",
-                "regjsgen": "0.5.0",
-                "regjsparser": "0.6.0",
-                "unicode-match-property-ecmascript": "1.0.4",
-                "unicode-match-property-value-ecmascript": "1.0.2"
+                "regenerate": "^1.4.0",
+                "regenerate-unicode-properties": "^7.0.0",
+                "regjsgen": "^0.5.0",
+                "regjsparser": "^0.6.0",
+                "unicode-match-property-ecmascript": "^1.0.4",
+                "unicode-match-property-value-ecmascript": "^1.0.2"
               }
             },
             "regjsgen": {
@@ -3528,7 +3580,7 @@
               "version": "0.6.0",
               "bundled": true,
               "requires": {
-                "jsesc": "0.5.0"
+                "jsesc": "~0.5.0"
               },
               "dependencies": {
                 "jsesc": {
@@ -3553,7 +3605,7 @@
               "version": "2.0.1",
               "bundled": true,
               "requires": {
-                "is-finite": "1.0.2"
+                "is-finite": "^1.0.0"
               }
             },
             "require-directory": {
@@ -3568,7 +3620,7 @@
               "version": "1.10.0",
               "bundled": true,
               "requires": {
-                "path-parse": "1.0.6"
+                "path-parse": "^1.0.6"
               }
             },
             "resolve-from": {
@@ -3579,7 +3631,7 @@
               "version": "1.0.0",
               "bundled": true,
               "requires": {
-                "resolve-from": "2.0.0"
+                "resolve-from": "^2.0.0"
               }
             },
             "resolve-url": {
@@ -3594,7 +3646,7 @@
               "version": "2.6.3",
               "bundled": true,
               "requires": {
-                "glob": "7.1.3"
+                "glob": "^7.1.3"
               }
             },
             "safe-buffer": {
@@ -3605,7 +3657,7 @@
               "version": "1.1.0",
               "bundled": true,
               "requires": {
-                "ret": "0.1.15"
+                "ret": "~0.1.10"
               }
             },
             "safer-buffer": {
@@ -3628,17 +3680,17 @@
               "version": "2.0.0",
               "bundled": true,
               "requires": {
-                "extend-shallow": "2.0.1",
-                "is-extendable": "0.1.1",
-                "is-plain-object": "2.0.4",
-                "split-string": "3.1.0"
+                "extend-shallow": "^2.0.1",
+                "is-extendable": "^0.1.1",
+                "is-plain-object": "^2.0.3",
+                "split-string": "^3.0.1"
               },
               "dependencies": {
                 "extend-shallow": {
                   "version": "2.0.1",
                   "bundled": true,
                   "requires": {
-                    "is-extendable": "0.1.1"
+                    "is-extendable": "^0.1.0"
                   }
                 }
               }
@@ -3647,7 +3699,7 @@
               "version": "1.2.0",
               "bundled": true,
               "requires": {
-                "shebang-regex": "1.0.0"
+                "shebang-regex": "^1.0.0"
               }
             },
             "shebang-regex": {
@@ -3666,28 +3718,28 @@
               "version": "0.8.2",
               "bundled": true,
               "requires": {
-                "base": "0.11.2",
-                "debug": "2.6.9",
-                "define-property": "0.2.5",
-                "extend-shallow": "2.0.1",
-                "map-cache": "0.2.2",
-                "source-map": "0.5.7",
-                "source-map-resolve": "0.5.2",
-                "use": "3.1.1"
+                "base": "^0.11.1",
+                "debug": "^2.2.0",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "map-cache": "^0.2.2",
+                "source-map": "^0.5.6",
+                "source-map-resolve": "^0.5.0",
+                "use": "^3.1.0"
               },
               "dependencies": {
                 "define-property": {
                   "version": "0.2.5",
                   "bundled": true,
                   "requires": {
-                    "is-descriptor": "0.1.6"
+                    "is-descriptor": "^0.1.0"
                   }
                 },
                 "extend-shallow": {
                   "version": "2.0.1",
                   "bundled": true,
                   "requires": {
-                    "is-extendable": "0.1.1"
+                    "is-extendable": "^0.1.0"
                   }
                 }
               }
@@ -3696,39 +3748,39 @@
               "version": "2.1.1",
               "bundled": true,
               "requires": {
-                "define-property": "1.0.0",
-                "isobject": "3.0.1",
-                "snapdragon-util": "3.0.1"
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.0",
+                "snapdragon-util": "^3.0.1"
               },
               "dependencies": {
                 "define-property": {
                   "version": "1.0.0",
                   "bundled": true,
                   "requires": {
-                    "is-descriptor": "1.0.2"
+                    "is-descriptor": "^1.0.0"
                   }
                 },
                 "is-accessor-descriptor": {
                   "version": "1.0.0",
                   "bundled": true,
                   "requires": {
-                    "kind-of": "6.0.2"
+                    "kind-of": "^6.0.0"
                   }
                 },
                 "is-data-descriptor": {
                   "version": "1.0.0",
                   "bundled": true,
                   "requires": {
-                    "kind-of": "6.0.2"
+                    "kind-of": "^6.0.0"
                   }
                 },
                 "is-descriptor": {
                   "version": "1.0.2",
                   "bundled": true,
                   "requires": {
-                    "is-accessor-descriptor": "1.0.0",
-                    "is-data-descriptor": "1.0.0",
-                    "kind-of": "6.0.2"
+                    "is-accessor-descriptor": "^1.0.0",
+                    "is-data-descriptor": "^1.0.0",
+                    "kind-of": "^6.0.2"
                   }
                 }
               }
@@ -3737,14 +3789,14 @@
               "version": "3.0.1",
               "bundled": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.2.0"
               },
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
                   "bundled": true,
                   "requires": {
-                    "is-buffer": "1.1.6"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -3757,11 +3809,11 @@
               "version": "0.5.2",
               "bundled": true,
               "requires": {
-                "atob": "2.1.2",
-                "decode-uri-component": "0.2.0",
-                "resolve-url": "0.2.1",
-                "source-map-url": "0.4.0",
-                "urix": "0.1.0"
+                "atob": "^2.1.1",
+                "decode-uri-component": "^0.2.0",
+                "resolve-url": "^0.2.1",
+                "source-map-url": "^0.4.0",
+                "urix": "^0.1.0"
               }
             },
             "source-map-url": {
@@ -3772,8 +3824,8 @@
               "version": "3.1.0",
               "bundled": true,
               "requires": {
-                "spdx-expression-parse": "3.0.0",
-                "spdx-license-ids": "3.0.3"
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
               }
             },
             "spdx-exceptions": {
@@ -3784,8 +3836,8 @@
               "version": "3.0.0",
               "bundled": true,
               "requires": {
-                "spdx-exceptions": "2.2.0",
-                "spdx-license-ids": "3.0.3"
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
               }
             },
             "spdx-license-ids": {
@@ -3796,7 +3848,7 @@
               "version": "3.1.0",
               "bundled": true,
               "requires": {
-                "extend-shallow": "3.0.2"
+                "extend-shallow": "^3.0.0"
               }
             },
             "sprintf-js": {
@@ -3807,15 +3859,15 @@
               "version": "0.1.2",
               "bundled": true,
               "requires": {
-                "define-property": "0.2.5",
-                "object-copy": "0.1.0"
+                "define-property": "^0.2.5",
+                "object-copy": "^0.1.0"
               },
               "dependencies": {
                 "define-property": {
                   "version": "0.2.5",
                   "bundled": true,
                   "requires": {
-                    "is-descriptor": "0.1.6"
+                    "is-descriptor": "^0.1.0"
                   }
                 }
               }
@@ -3824,8 +3876,8 @@
               "version": "2.1.1",
               "bundled": true,
               "requires": {
-                "is-fullwidth-code-point": "2.0.0",
-                "strip-ansi": "4.0.0"
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
               },
               "dependencies": {
                 "ansi-regex": {
@@ -3836,7 +3888,7 @@
                   "version": "4.0.0",
                   "bundled": true,
                   "requires": {
-                    "ansi-regex": "3.0.0"
+                    "ansi-regex": "^3.0.0"
                   }
                 }
               }
@@ -3845,21 +3897,21 @@
               "version": "1.1.1",
               "bundled": true,
               "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "~5.1.0"
               }
             },
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
               "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
               }
             },
             "strip-bom": {
               "version": "2.0.0",
               "bundled": true,
               "requires": {
-                "is-utf8": "0.2.1"
+                "is-utf8": "^0.2.0"
               }
             },
             "strip-eof": {
@@ -3870,7 +3922,7 @@
               "version": "1.0.1",
               "bundled": true,
               "requires": {
-                "get-stdin": "4.0.1"
+                "get-stdin": "^4.0.1"
               }
             },
             "supports-color": {
@@ -3885,14 +3937,14 @@
               "version": "0.3.0",
               "bundled": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
                   "bundled": true,
                   "requires": {
-                    "is-buffer": "1.1.6"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -3901,18 +3953,18 @@
               "version": "3.0.2",
               "bundled": true,
               "requires": {
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "regex-not": "1.0.2",
-                "safe-regex": "1.1.0"
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "regex-not": "^1.0.2",
+                "safe-regex": "^1.1.0"
               }
             },
             "to-regex-range": {
               "version": "2.1.1",
               "bundled": true,
               "requires": {
-                "is-number": "3.0.0",
-                "repeat-string": "1.6.1"
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1"
               }
             },
             "trim-newlines": {
@@ -3931,18 +3983,18 @@
               "version": "5.12.1",
               "bundled": true,
               "requires": {
-                "babel-code-frame": "6.26.0",
-                "builtin-modules": "1.1.1",
-                "chalk": "2.4.2",
-                "commander": "2.19.0",
-                "diff": "3.5.0",
-                "glob": "7.1.3",
-                "js-yaml": "3.12.1",
-                "minimatch": "3.0.4",
-                "resolve": "1.10.0",
-                "semver": "5.6.0",
-                "tslib": "1.9.3",
-                "tsutils": "2.29.0"
+                "babel-code-frame": "^6.22.0",
+                "builtin-modules": "^1.1.1",
+                "chalk": "^2.3.0",
+                "commander": "^2.12.1",
+                "diff": "^3.2.0",
+                "glob": "^7.1.1",
+                "js-yaml": "^3.7.0",
+                "minimatch": "^3.0.4",
+                "resolve": "^1.3.2",
+                "semver": "^5.3.0",
+                "tslib": "^1.8.0",
+                "tsutils": "^2.27.2"
               }
             },
             "tslint-config-prettier": {
@@ -3953,7 +4005,7 @@
               "version": "2.29.0",
               "bundled": true,
               "requires": {
-                "tslib": "1.9.3"
+                "tslib": "^1.8.1"
               }
             },
             "typescript": {
@@ -3964,8 +4016,8 @@
               "version": "3.3.5",
               "bundled": true,
               "requires": {
-                "sprintf-js": "1.0.3",
-                "util-deprecate": "1.0.2"
+                "sprintf-js": "^1.0.3",
+                "util-deprecate": "^1.0.2"
               }
             },
             "unicode-canonical-property-names-ecmascript": {
@@ -3976,8 +4028,8 @@
               "version": "1.0.4",
               "bundled": true,
               "requires": {
-                "unicode-canonical-property-names-ecmascript": "1.0.4",
-                "unicode-property-aliases-ecmascript": "1.0.4"
+                "unicode-canonical-property-names-ecmascript": "^1.0.4",
+                "unicode-property-aliases-ecmascript": "^1.0.4"
               }
             },
             "unicode-match-property-value-ecmascript": {
@@ -3992,27 +4044,27 @@
               "version": "1.0.0",
               "bundled": true,
               "requires": {
-                "arr-union": "3.1.0",
-                "get-value": "2.0.6",
-                "is-extendable": "0.1.1",
-                "set-value": "0.4.3"
+                "arr-union": "^3.1.0",
+                "get-value": "^2.0.6",
+                "is-extendable": "^0.1.1",
+                "set-value": "^0.4.3"
               },
               "dependencies": {
                 "extend-shallow": {
                   "version": "2.0.1",
                   "bundled": true,
                   "requires": {
-                    "is-extendable": "0.1.1"
+                    "is-extendable": "^0.1.0"
                   }
                 },
                 "set-value": {
                   "version": "0.4.3",
                   "bundled": true,
                   "requires": {
-                    "extend-shallow": "2.0.1",
-                    "is-extendable": "0.1.1",
-                    "is-plain-object": "2.0.4",
-                    "to-object-path": "0.3.0"
+                    "extend-shallow": "^2.0.1",
+                    "is-extendable": "^0.1.1",
+                    "is-plain-object": "^2.0.1",
+                    "to-object-path": "^0.3.0"
                   }
                 }
               }
@@ -4021,17 +4073,17 @@
               "version": "1.0.0",
               "bundled": true,
               "requires": {
-                "has-value": "0.3.1",
-                "isobject": "3.0.1"
+                "has-value": "^0.3.1",
+                "isobject": "^3.0.0"
               },
               "dependencies": {
                 "has-value": {
                   "version": "0.3.1",
                   "bundled": true,
                   "requires": {
-                    "get-value": "2.0.6",
-                    "has-values": "0.1.4",
-                    "isobject": "2.1.0"
+                    "get-value": "^2.0.3",
+                    "has-values": "^0.1.4",
+                    "isobject": "^2.0.0"
                   },
                   "dependencies": {
                     "isobject": {
@@ -4069,15 +4121,15 @@
               "version": "3.0.4",
               "bundled": true,
               "requires": {
-                "spdx-correct": "3.1.0",
-                "spdx-expression-parse": "3.0.0"
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
               }
             },
             "which": {
               "version": "1.3.1",
               "bundled": true,
               "requires": {
-                "isexe": "2.0.0"
+                "isexe": "^2.0.0"
               }
             },
             "which-module": {
@@ -4088,24 +4140,24 @@
               "version": "2.1.0",
               "bundled": true,
               "requires": {
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1"
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1"
               },
               "dependencies": {
                 "is-fullwidth-code-point": {
                   "version": "1.0.0",
                   "bundled": true,
                   "requires": {
-                    "number-is-nan": "1.0.1"
+                    "number-is-nan": "^1.0.0"
                   }
                 },
                 "string-width": {
                   "version": "1.0.2",
                   "bundled": true,
                   "requires": {
-                    "code-point-at": "1.1.0",
-                    "is-fullwidth-code-point": "1.0.0",
-                    "strip-ansi": "3.0.1"
+                    "code-point-at": "^1.0.0",
+                    "is-fullwidth-code-point": "^1.0.0",
+                    "strip-ansi": "^3.0.0"
                   }
                 }
               }
@@ -4118,8 +4170,8 @@
               "version": "0.4.19",
               "bundled": true,
               "requires": {
-                "sax": "1.2.4",
-                "xmlbuilder": "9.0.7"
+                "sax": ">=0.6.0",
+                "xmlbuilder": "~9.0.1"
               }
             },
             "xmlbuilder": {
@@ -4138,25 +4190,25 @@
               "version": "10.1.2",
               "bundled": true,
               "requires": {
-                "cliui": "4.1.0",
-                "decamelize": "1.2.0",
-                "find-up": "2.1.0",
-                "get-caller-file": "1.0.3",
-                "os-locale": "2.1.0",
-                "require-directory": "2.1.1",
-                "require-main-filename": "1.0.1",
-                "set-blocking": "2.0.0",
-                "string-width": "2.1.1",
-                "which-module": "2.0.0",
-                "y18n": "3.2.1",
-                "yargs-parser": "8.1.0"
+                "cliui": "^4.0.0",
+                "decamelize": "^1.1.1",
+                "find-up": "^2.1.0",
+                "get-caller-file": "^1.0.1",
+                "os-locale": "^2.0.0",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^1.0.1",
+                "set-blocking": "^2.0.0",
+                "string-width": "^2.0.0",
+                "which-module": "^2.0.0",
+                "y18n": "^3.2.1",
+                "yargs-parser": "^8.1.0"
               },
               "dependencies": {
                 "find-up": {
                   "version": "2.1.0",
                   "bundled": true,
                   "requires": {
-                    "locate-path": "2.0.0"
+                    "locate-path": "^2.0.0"
                   }
                 }
               }
@@ -4165,7 +4217,7 @@
               "version": "8.1.0",
               "bundled": true,
               "requires": {
-                "camelcase": "4.1.0"
+                "camelcase": "^4.1.0"
               },
               "dependencies": {
                 "camelcase": {
@@ -4177,26 +4229,26 @@
           }
         },
         "duplexify": {
-          "version": "3.6.1",
+          "version": "3.7.1",
           "bundled": true,
           "requires": {
-            "end-of-stream": "1.4.1",
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.6",
-            "stream-shift": "1.0.0"
+            "end-of-stream": "^1.0.0",
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.0",
+            "stream-shift": "^1.0.0"
           }
         },
         "elliptic": {
           "version": "6.4.1",
           "bundled": true,
           "requires": {
-            "bn.js": "4.11.8",
-            "brorand": "1.1.0",
-            "hash.js": "1.1.7",
-            "hmac-drbg": "1.0.1",
-            "inherits": "2.0.3",
-            "minimalistic-assert": "1.0.1",
-            "minimalistic-crypto-utils": "1.0.1"
+            "bn.js": "^4.4.0",
+            "brorand": "^1.0.1",
+            "hash.js": "^1.0.0",
+            "hmac-drbg": "^1.0.0",
+            "inherits": "^2.0.1",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.0"
           }
         },
         "emojis-list": {
@@ -4207,30 +4259,30 @@
           "version": "1.4.1",
           "bundled": true,
           "requires": {
-            "once": "1.4.0"
+            "once": "^1.4.0"
           }
         },
         "enhanced-resolve": {
           "version": "4.1.0",
           "bundled": true,
           "requires": {
-            "graceful-fs": "4.1.15",
-            "memory-fs": "0.4.1",
-            "tapable": "1.1.1"
+            "graceful-fs": "^4.1.2",
+            "memory-fs": "^0.4.0",
+            "tapable": "^1.0.0"
           }
         },
         "errno": {
           "version": "0.1.7",
           "bundled": true,
           "requires": {
-            "prr": "1.0.1"
+            "prr": "~1.0.1"
           }
         },
         "error-ex": {
           "version": "1.3.2",
           "bundled": true,
           "requires": {
-            "is-arrayish": "0.2.1"
+            "is-arrayish": "^0.2.1"
           }
         },
         "escape-string-regexp": {
@@ -4241,8 +4293,8 @@
           "version": "4.0.0",
           "bundled": true,
           "requires": {
-            "esrecurse": "4.2.1",
-            "estraverse": "4.2.0"
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
           }
         },
         "esprima": {
@@ -4253,7 +4305,7 @@
           "version": "4.2.1",
           "bundled": true,
           "requires": {
-            "estraverse": "4.2.0"
+            "estraverse": "^4.1.0"
           }
         },
         "estraverse": {
@@ -4276,48 +4328,48 @@
           "version": "1.0.3",
           "bundled": true,
           "requires": {
-            "md5.js": "1.3.5",
-            "safe-buffer": "5.1.2"
+            "md5.js": "^1.3.4",
+            "safe-buffer": "^5.1.1"
           }
         },
         "execa": {
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "cross-spawn": "6.0.5",
-            "get-stream": "4.1.0",
-            "is-stream": "1.1.0",
-            "npm-run-path": "2.0.2",
-            "p-finally": "1.0.0",
-            "signal-exit": "3.0.2",
-            "strip-eof": "1.0.0"
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
           }
         },
         "expand-brackets": {
           "version": "2.1.4",
           "bundled": true,
           "requires": {
-            "debug": "2.6.9",
-            "define-property": "0.2.5",
-            "extend-shallow": "2.0.1",
-            "posix-character-classes": "0.1.1",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
+            "debug": "^2.3.3",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "posix-character-classes": "^0.1.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
               "bundled": true,
               "requires": {
-                "is-descriptor": "0.1.6"
+                "is-descriptor": "^0.1.0"
               }
             },
             "extend-shallow": {
               "version": "2.0.1",
               "bundled": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -4326,22 +4378,22 @@
           "version": "2.0.2",
           "bundled": true,
           "requires": {
-            "homedir-polyfill": "1.0.1"
+            "homedir-polyfill": "^1.0.1"
           }
         },
         "extend-shallow": {
           "version": "3.0.2",
           "bundled": true,
           "requires": {
-            "assign-symbols": "1.0.0",
-            "is-extendable": "1.0.1"
+            "assign-symbols": "^1.0.0",
+            "is-extendable": "^1.0.1"
           },
           "dependencies": {
             "is-extendable": {
               "version": "1.0.1",
               "bundled": true,
               "requires": {
-                "is-plain-object": "2.0.4"
+                "is-plain-object": "^2.0.4"
               }
             }
           }
@@ -4350,51 +4402,51 @@
           "version": "2.0.4",
           "bundled": true,
           "requires": {
-            "array-unique": "0.3.2",
-            "define-property": "1.0.0",
-            "expand-brackets": "2.1.4",
-            "extend-shallow": "2.0.1",
-            "fragment-cache": "0.2.1",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
+            "array-unique": "^0.3.2",
+            "define-property": "^1.0.0",
+            "expand-brackets": "^2.1.4",
+            "extend-shallow": "^2.0.1",
+            "fragment-cache": "^0.2.1",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
           },
           "dependencies": {
             "define-property": {
               "version": "1.0.0",
               "bundled": true,
               "requires": {
-                "is-descriptor": "1.0.2"
+                "is-descriptor": "^1.0.0"
               }
             },
             "extend-shallow": {
               "version": "2.0.1",
               "bundled": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             },
             "is-accessor-descriptor": {
               "version": "1.0.0",
               "bundled": true,
               "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.0"
               }
             },
             "is-data-descriptor": {
               "version": "1.0.0",
               "bundled": true,
               "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.0"
               }
             },
             "is-descriptor": {
               "version": "1.0.2",
               "bundled": true,
               "requires": {
-                "is-accessor-descriptor": "1.0.0",
-                "is-data-descriptor": "1.0.0",
-                "kind-of": "6.0.2"
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
               }
             }
           }
@@ -4415,17 +4467,17 @@
           "version": "4.0.0",
           "bundled": true,
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-number": "3.0.0",
-            "repeat-string": "1.6.1",
-            "to-regex-range": "2.1.1"
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
           },
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
               "bundled": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -4434,35 +4486,44 @@
           "version": "2.0.0",
           "bundled": true,
           "requires": {
-            "commondir": "1.0.1",
-            "make-dir": "1.3.0",
-            "pkg-dir": "3.0.0"
+            "commondir": "^1.0.1",
+            "make-dir": "^1.0.0",
+            "pkg-dir": "^3.0.0"
           }
         },
         "find-up": {
           "version": "1.1.2",
           "bundled": true,
           "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
+            "path-exists": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "findup-sync": {
           "version": "2.0.0",
           "bundled": true,
           "requires": {
-            "detect-file": "1.0.0",
-            "is-glob": "3.1.0",
-            "micromatch": "3.1.10",
-            "resolve-dir": "1.0.1"
+            "detect-file": "^1.0.0",
+            "is-glob": "^3.1.0",
+            "micromatch": "^3.0.4",
+            "resolve-dir": "^1.0.1"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "3.1.0",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^2.1.0"
+              }
+            }
           }
         },
         "flush-write-stream": {
-          "version": "1.0.3",
+          "version": "1.1.1",
           "bundled": true,
           "requires": {
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.6"
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.3.6"
           }
         },
         "for-in": {
@@ -4473,32 +4534,32 @@
           "version": "0.2.1",
           "bundled": true,
           "requires": {
-            "map-cache": "0.2.2"
+            "map-cache": "^0.2.2"
           }
         },
         "from2": {
           "version": "2.3.0",
           "bundled": true,
           "requires": {
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.6"
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.0.0"
           }
         },
         "fs-minipass": {
           "version": "1.2.5",
           "bundled": true,
           "requires": {
-            "minipass": "2.3.5"
+            "minipass": "^2.2.1"
           }
         },
         "fs-write-stream-atomic": {
           "version": "1.0.10",
           "bundled": true,
           "requires": {
-            "graceful-fs": "4.1.15",
-            "iferr": "0.1.5",
-            "imurmurhash": "0.1.4",
-            "readable-stream": "2.3.6"
+            "graceful-fs": "^4.1.2",
+            "iferr": "^0.1.5",
+            "imurmurhash": "^0.1.4",
+            "readable-stream": "1 || 2"
           }
         },
         "fs.realpath": {
@@ -4509,14 +4570,14 @@
           "version": "2.7.4",
           "bundled": true,
           "requires": {
-            "aproba": "1.2.0",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.3"
+            "aproba": "^1.0.3",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.0",
+            "object-assign": "^4.1.0",
+            "signal-exit": "^3.0.0",
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wide-align": "^1.1.0"
           }
         },
         "get-caller-file": {
@@ -4527,7 +4588,7 @@
           "version": "4.1.0",
           "bundled": true,
           "requires": {
-            "pump": "3.0.0"
+            "pump": "^3.0.0"
           }
         },
         "get-value": {
@@ -4538,44 +4599,49 @@
           "version": "7.1.3",
           "bundled": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "glob-parent": {
           "version": "3.1.0",
           "bundled": true,
           "requires": {
-            "is-glob": "3.1.0",
-            "path-dirname": "1.0.2"
+            "is-glob": "^3.1.0",
+            "path-dirname": "^1.0.0"
+          },
+          "dependencies": {
+            "is-glob": {
+              "version": "3.1.0",
+              "bundled": true,
+              "requires": {
+                "is-extglob": "^2.1.0"
+              }
+            }
           }
         },
         "global-modules": {
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "global-prefix": "1.0.2",
-            "is-windows": "1.0.2",
-            "resolve-dir": "1.0.1"
+            "global-prefix": "^1.0.1",
+            "is-windows": "^1.0.1",
+            "resolve-dir": "^1.0.0"
           }
-        },
-        "global-modules-path": {
-          "version": "2.3.1",
-          "bundled": true
         },
         "global-prefix": {
           "version": "1.0.2",
           "bundled": true,
           "requires": {
-            "expand-tilde": "2.0.2",
-            "homedir-polyfill": "1.0.1",
-            "ini": "1.3.5",
-            "is-windows": "1.0.2",
-            "which": "1.3.1"
+            "expand-tilde": "^2.0.2",
+            "homedir-polyfill": "^1.0.1",
+            "ini": "^1.3.4",
+            "is-windows": "^1.0.1",
+            "which": "^1.2.14"
           }
         },
         "graceful-fs": {
@@ -4583,21 +4649,21 @@
           "bundled": true
         },
         "graphql": {
-          "version": "14.0.2",
+          "version": "14.1.1",
           "bundled": true,
           "requires": {
-            "iterall": "1.2.2"
+            "iterall": "^1.2.2"
           }
         },
         "graphql-tag": {
-          "version": "2.10.0",
+          "version": "2.10.1",
           "bundled": true
         },
         "has-ansi": {
           "version": "2.0.0",
           "bundled": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "has-flag": {
@@ -4612,24 +4678,24 @@
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "get-value": "2.0.6",
-            "has-values": "1.0.0",
-            "isobject": "3.0.1"
+            "get-value": "^2.0.6",
+            "has-values": "^1.0.0",
+            "isobject": "^3.0.0"
           }
         },
         "has-values": {
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "is-number": "3.0.0",
-            "kind-of": "4.0.0"
+            "is-number": "^3.0.0",
+            "kind-of": "^4.0.0"
           },
           "dependencies": {
             "kind-of": {
               "version": "4.0.0",
               "bundled": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -4638,32 +4704,32 @@
           "version": "3.0.4",
           "bundled": true,
           "requires": {
-            "inherits": "2.0.3",
-            "safe-buffer": "5.1.2"
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
           }
         },
         "hash.js": {
           "version": "1.1.7",
           "bundled": true,
           "requires": {
-            "inherits": "2.0.3",
-            "minimalistic-assert": "1.0.1"
+            "inherits": "^2.0.3",
+            "minimalistic-assert": "^1.0.1"
           }
         },
         "hmac-drbg": {
           "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "hash.js": "1.1.7",
-            "minimalistic-assert": "1.0.1",
-            "minimalistic-crypto-utils": "1.0.1"
+            "hash.js": "^1.0.3",
+            "minimalistic-assert": "^1.0.0",
+            "minimalistic-crypto-utils": "^1.0.1"
           }
         },
         "homedir-polyfill": {
           "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "parse-passwd": "1.0.0"
+            "parse-passwd": "^1.0.0"
           }
         },
         "hosted-git-info": {
@@ -4678,7 +4744,7 @@
           "version": "0.4.24",
           "bundled": true,
           "requires": {
-            "safer-buffer": "2.1.2"
+            "safer-buffer": ">= 2.1.2 < 3"
           }
         },
         "ieee754": {
@@ -4693,19 +4759,19 @@
           "version": "3.0.1",
           "bundled": true,
           "requires": {
-            "minimatch": "3.0.4"
+            "minimatch": "^3.0.4"
           }
         },
         "immutable-tuple": {
-          "version": "0.4.9",
+          "version": "0.4.10",
           "bundled": true
         },
         "import-local": {
           "version": "2.0.0",
           "bundled": true,
           "requires": {
-            "pkg-dir": "3.0.0",
-            "resolve-cwd": "2.0.0"
+            "pkg-dir": "^3.0.0",
+            "resolve-cwd": "^2.0.0"
           }
         },
         "imurmurhash": {
@@ -4720,8 +4786,8 @@
           "version": "1.0.6",
           "bundled": true,
           "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
+            "once": "^1.3.0",
+            "wrappy": "1"
           }
         },
         "inherits": {
@@ -4744,14 +4810,14 @@
           "version": "0.1.6",
           "bundled": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
               "bundled": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -4764,32 +4830,25 @@
           "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "binary-extensions": "1.12.0"
+            "binary-extensions": "^1.0.0"
           }
         },
         "is-buffer": {
           "version": "1.1.6",
           "bundled": true
         },
-        "is-builtin-module": {
-          "version": "1.0.0",
-          "bundled": true,
-          "requires": {
-            "builtin-modules": "1.1.1"
-          }
-        },
         "is-data-descriptor": {
           "version": "0.1.4",
           "bundled": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
               "bundled": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -4798,9 +4857,9 @@
           "version": "0.1.6",
           "bundled": true,
           "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
           },
           "dependencies": {
             "kind-of": {
@@ -4821,28 +4880,28 @@
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "is-glob": {
-          "version": "3.1.0",
+          "version": "4.0.0",
           "bundled": true,
           "requires": {
-            "is-extglob": "2.1.1"
+            "is-extglob": "^2.1.1"
           }
         },
         "is-number": {
           "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
               "bundled": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -4851,7 +4910,7 @@
           "version": "2.0.4",
           "bundled": true,
           "requires": {
-            "isobject": "3.0.1"
+            "isobject": "^3.0.1"
           }
         },
         "is-stream": {
@@ -4890,8 +4949,8 @@
           "version": "3.12.1",
           "bundled": true,
           "requires": {
-            "argparse": "1.0.10",
-            "esprima": "4.0.1"
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
           }
         },
         "json-parse-better-errors": {
@@ -4906,7 +4965,7 @@
           "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "minimist": "1.2.0"
+            "minimist": "^1.2.0"
           },
           "dependencies": {
             "minimist": {
@@ -4923,22 +4982,18 @@
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "invert-kv": "1.0.0"
+            "invert-kv": "^1.0.0"
           }
-        },
-        "lightercollective": {
-          "version": "0.1.0",
-          "bundled": true
         },
         "load-json-file": {
           "version": "1.1.0",
           "bundled": true,
           "requires": {
-            "graceful-fs": "4.1.15",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0",
+            "strip-bom": "^2.0.0"
           }
         },
         "loader-runner": {
@@ -4949,17 +5004,17 @@
           "version": "1.2.3",
           "bundled": true,
           "requires": {
-            "big.js": "5.2.2",
-            "emojis-list": "2.1.0",
-            "json5": "1.0.1"
+            "big.js": "^5.2.2",
+            "emojis-list": "^2.0.0",
+            "json5": "^1.0.1"
           }
         },
         "locate-path": {
           "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "p-locate": "3.0.0",
-            "path-exists": "3.0.0"
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
           },
           "dependencies": {
             "path-exists": {
@@ -4968,22 +5023,18 @@
             }
           }
         },
-        "lodash.debounce": {
-          "version": "4.0.8",
-          "bundled": true
-        },
         "lru-cache": {
           "version": "5.1.1",
           "bundled": true,
           "requires": {
-            "yallist": "3.0.3"
+            "yallist": "^3.0.2"
           }
         },
         "make-dir": {
           "version": "1.3.0",
           "bundled": true,
           "requires": {
-            "pify": "3.0.0"
+            "pify": "^3.0.0"
           },
           "dependencies": {
             "pify": {
@@ -4996,7 +5047,7 @@
           "version": "0.1.3",
           "bundled": true,
           "requires": {
-            "p-defer": "1.0.0"
+            "p-defer": "^1.0.0"
           }
         },
         "map-cache": {
@@ -5007,60 +5058,60 @@
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "object-visit": "1.0.1"
+            "object-visit": "^1.0.0"
           }
         },
         "md5.js": {
           "version": "1.3.5",
           "bundled": true,
           "requires": {
-            "hash-base": "3.0.4",
-            "inherits": "2.0.3",
-            "safe-buffer": "5.1.2"
+            "hash-base": "^3.0.0",
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.1.2"
           }
         },
         "mem": {
-          "version": "4.0.0",
+          "version": "4.1.0",
           "bundled": true,
           "requires": {
-            "map-age-cleaner": "0.1.3",
-            "mimic-fn": "1.2.0",
-            "p-is-promise": "1.1.0"
+            "map-age-cleaner": "^0.1.1",
+            "mimic-fn": "^1.0.0",
+            "p-is-promise": "^2.0.0"
           }
         },
         "memory-fs": {
           "version": "0.4.1",
           "bundled": true,
           "requires": {
-            "errno": "0.1.7",
-            "readable-stream": "2.3.6"
+            "errno": "^0.1.3",
+            "readable-stream": "^2.0.1"
           }
         },
         "micromatch": {
           "version": "3.1.10",
           "bundled": true,
           "requires": {
-            "arr-diff": "4.0.0",
-            "array-unique": "0.3.2",
-            "braces": "2.3.2",
-            "define-property": "2.0.2",
-            "extend-shallow": "3.0.2",
-            "extglob": "2.0.4",
-            "fragment-cache": "0.2.1",
-            "kind-of": "6.0.2",
-            "nanomatch": "1.2.13",
-            "object.pick": "1.3.0",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
           }
         },
         "miller-rabin": {
           "version": "4.0.1",
           "bundled": true,
           "requires": {
-            "bn.js": "4.11.8",
-            "brorand": "1.1.0"
+            "bn.js": "^4.0.0",
+            "brorand": "^1.0.1"
           }
         },
         "mimic-fn": {
@@ -5079,7 +5130,7 @@
           "version": "3.0.4",
           "bundled": true,
           "requires": {
-            "brace-expansion": "1.1.11"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -5090,46 +5141,46 @@
           "version": "2.3.5",
           "bundled": true,
           "requires": {
-            "safe-buffer": "5.1.2",
-            "yallist": "3.0.3"
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.0"
           }
         },
         "minizlib": {
           "version": "1.2.1",
           "bundled": true,
           "requires": {
-            "minipass": "2.3.5"
+            "minipass": "^2.2.1"
           }
         },
         "mississippi": {
           "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "concat-stream": "1.6.2",
-            "duplexify": "3.6.1",
-            "end-of-stream": "1.4.1",
-            "flush-write-stream": "1.0.3",
-            "from2": "2.3.0",
-            "parallel-transform": "1.1.0",
-            "pump": "3.0.0",
-            "pumpify": "1.5.1",
-            "stream-each": "1.2.3",
-            "through2": "2.0.5"
+            "concat-stream": "^1.5.0",
+            "duplexify": "^3.4.2",
+            "end-of-stream": "^1.1.0",
+            "flush-write-stream": "^1.0.0",
+            "from2": "^2.1.0",
+            "parallel-transform": "^1.1.0",
+            "pump": "^3.0.0",
+            "pumpify": "^1.3.3",
+            "stream-each": "^1.1.0",
+            "through2": "^2.0.0"
           }
         },
         "mixin-deep": {
           "version": "1.3.1",
           "bundled": true,
           "requires": {
-            "for-in": "1.0.2",
-            "is-extendable": "1.0.1"
+            "for-in": "^1.0.2",
+            "is-extendable": "^1.0.1"
           },
           "dependencies": {
             "is-extendable": {
               "version": "1.0.1",
               "bundled": true,
               "requires": {
-                "is-plain-object": "2.0.4"
+                "is-plain-object": "^2.0.4"
               }
             }
           }
@@ -5145,12 +5196,12 @@
           "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "aproba": "1.2.0",
-            "copy-concurrently": "1.0.5",
-            "fs-write-stream-atomic": "1.0.10",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.3",
-            "run-queue": "1.0.3"
+            "aproba": "^1.1.1",
+            "copy-concurrently": "^1.0.0",
+            "fs-write-stream-atomic": "^1.0.8",
+            "mkdirp": "^0.5.1",
+            "rimraf": "^2.5.4",
+            "run-queue": "^1.0.3"
           }
         },
         "ms": {
@@ -5165,26 +5216,26 @@
           "version": "1.2.13",
           "bundled": true,
           "requires": {
-            "arr-diff": "4.0.0",
-            "array-unique": "0.3.2",
-            "define-property": "2.0.2",
-            "extend-shallow": "3.0.2",
-            "fragment-cache": "0.2.1",
-            "is-windows": "1.0.2",
-            "kind-of": "6.0.2",
-            "object.pick": "1.3.0",
-            "regex-not": "1.0.2",
-            "snapdragon": "0.8.2",
-            "to-regex": "3.0.2"
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "fragment-cache": "^0.2.1",
+            "is-windows": "^1.0.2",
+            "kind-of": "^6.0.2",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.1"
           }
         },
         "needle": {
           "version": "2.2.4",
           "bundled": true,
           "requires": {
-            "debug": "2.6.9",
-            "iconv-lite": "0.4.24",
-            "sax": "1.2.4"
+            "debug": "^2.1.2",
+            "iconv-lite": "^0.4.4",
+            "sax": "^1.2.4"
           }
         },
         "neo-async": {
@@ -5199,9 +5250,9 @@
           "version": "2.3.2",
           "bundled": true,
           "requires": {
-            "nan": "2.12.1",
-            "which": "1.3.1",
-            "yargs": "7.1.0"
+            "nan": "*",
+            "which": "^1.2.14",
+            "yargs": "^7.0.2"
           }
         },
         "node-fetch": {
@@ -5212,28 +5263,28 @@
           "version": "2.2.0",
           "bundled": true,
           "requires": {
-            "assert": "1.4.1",
-            "browserify-zlib": "0.2.0",
-            "buffer": "4.9.1",
-            "console-browserify": "1.1.0",
-            "constants-browserify": "1.0.0",
-            "crypto-browserify": "3.12.0",
-            "domain-browser": "1.2.0",
-            "events": "3.0.0",
-            "https-browserify": "1.0.0",
-            "os-browserify": "0.3.0",
+            "assert": "^1.1.1",
+            "browserify-zlib": "^0.2.0",
+            "buffer": "^4.3.0",
+            "console-browserify": "^1.1.0",
+            "constants-browserify": "^1.0.0",
+            "crypto-browserify": "^3.11.0",
+            "domain-browser": "^1.1.1",
+            "events": "^3.0.0",
+            "https-browserify": "^1.0.0",
+            "os-browserify": "^0.3.0",
             "path-browserify": "0.0.0",
-            "process": "0.11.10",
-            "punycode": "1.4.1",
-            "querystring-es3": "0.2.1",
-            "readable-stream": "2.3.6",
-            "stream-browserify": "2.0.1",
-            "stream-http": "2.8.3",
-            "string_decoder": "1.1.1",
-            "timers-browserify": "2.0.10",
+            "process": "^0.11.10",
+            "punycode": "^1.2.4",
+            "querystring-es3": "^0.2.0",
+            "readable-stream": "^2.3.3",
+            "stream-browserify": "^2.0.1",
+            "stream-http": "^2.7.2",
+            "string_decoder": "^1.0.0",
+            "timers-browserify": "^2.0.4",
             "tty-browserify": "0.0.0",
-            "url": "0.11.0",
-            "util": "0.11.1",
+            "url": "^0.11.0",
+            "util": "^0.11.0",
             "vm-browserify": "0.0.4"
           },
           "dependencies": {
@@ -5247,70 +5298,67 @@
           "version": "0.11.0",
           "bundled": true,
           "requires": {
-            "detect-libc": "1.0.3",
-            "mkdirp": "0.5.1",
-            "needle": "2.2.4",
-            "nopt": "4.0.1",
-            "npm-packlist": "1.2.0",
-            "npmlog": "4.1.2",
-            "rc": "1.2.8",
-            "rimraf": "2.6.3",
-            "semver": "5.6.0",
-            "tar": "4.4.8"
+            "detect-libc": "^1.0.2",
+            "mkdirp": "^0.5.1",
+            "needle": "^2.2.1",
+            "nopt": "^4.0.1",
+            "npm-packlist": "^1.1.6",
+            "npmlog": "^4.0.2",
+            "rc": "^1.2.7",
+            "rimraf": "^2.6.1",
+            "semver": "^5.3.0",
+            "tar": "^4"
           }
         },
         "nopt": {
           "version": "4.0.1",
           "bundled": true,
           "requires": {
-            "abbrev": "1.1.1",
-            "osenv": "0.1.5"
+            "abbrev": "1",
+            "osenv": "^0.1.4"
           }
         },
         "normalize-package-data": {
-          "version": "2.4.0",
+          "version": "2.5.0",
           "bundled": true,
           "requires": {
-            "hosted-git-info": "2.7.1",
-            "is-builtin-module": "1.0.0",
-            "semver": "5.6.0",
-            "validate-npm-package-license": "3.0.4"
+            "hosted-git-info": "^2.1.4",
+            "resolve": "^1.10.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
           }
         },
         "normalize-path": {
-          "version": "2.1.1",
-          "bundled": true,
-          "requires": {
-            "remove-trailing-separator": "1.1.0"
-          }
+          "version": "3.0.0",
+          "bundled": true
         },
         "npm-bundled": {
-          "version": "1.0.5",
+          "version": "1.0.6",
           "bundled": true
         },
         "npm-packlist": {
-          "version": "1.2.0",
+          "version": "1.3.0",
           "bundled": true,
           "requires": {
-            "ignore-walk": "3.0.1",
-            "npm-bundled": "1.0.5"
+            "ignore-walk": "^3.0.1",
+            "npm-bundled": "^1.0.1"
           }
         },
         "npm-run-path": {
           "version": "2.0.2",
           "bundled": true,
           "requires": {
-            "path-key": "2.0.1"
+            "path-key": "^2.0.0"
           }
         },
         "npmlog": {
           "version": "4.1.2",
           "bundled": true,
           "requires": {
-            "are-we-there-yet": "1.1.5",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
+            "are-we-there-yet": "~1.1.2",
+            "console-control-strings": "~1.1.0",
+            "gauge": "~2.7.3",
+            "set-blocking": "~2.0.0"
           }
         },
         "number-is-nan": {
@@ -5325,23 +5373,23 @@
           "version": "0.1.0",
           "bundled": true,
           "requires": {
-            "copy-descriptor": "0.1.1",
-            "define-property": "0.2.5",
-            "kind-of": "3.2.2"
+            "copy-descriptor": "^0.1.0",
+            "define-property": "^0.2.5",
+            "kind-of": "^3.0.3"
           },
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
               "bundled": true,
               "requires": {
-                "is-descriptor": "0.1.6"
+                "is-descriptor": "^0.1.0"
               }
             },
             "kind-of": {
               "version": "3.2.2",
               "bundled": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -5350,28 +5398,28 @@
           "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "isobject": "3.0.1"
+            "isobject": "^3.0.0"
           }
         },
         "object.pick": {
           "version": "1.3.0",
           "bundled": true,
           "requires": {
-            "isobject": "3.0.1"
+            "isobject": "^3.0.1"
           }
         },
         "once": {
           "version": "1.4.0",
           "bundled": true,
           "requires": {
-            "wrappy": "1.0.2"
+            "wrappy": "1"
           }
         },
         "optimism": {
-          "version": "0.6.8",
+          "version": "0.6.9",
           "bundled": true,
           "requires": {
-            "immutable-tuple": "0.4.9"
+            "immutable-tuple": "^0.4.9"
           }
         },
         "os-browserify": {
@@ -5386,7 +5434,7 @@
           "version": "1.4.0",
           "bundled": true,
           "requires": {
-            "lcid": "1.0.0"
+            "lcid": "^1.0.0"
           }
         },
         "os-tmpdir": {
@@ -5397,8 +5445,8 @@
           "version": "0.1.5",
           "bundled": true,
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
           }
         },
         "p-defer": {
@@ -5410,21 +5458,21 @@
           "bundled": true
         },
         "p-is-promise": {
-          "version": "1.1.0",
+          "version": "2.0.0",
           "bundled": true
         },
         "p-limit": {
           "version": "2.1.0",
           "bundled": true,
           "requires": {
-            "p-try": "2.0.0"
+            "p-try": "^2.0.0"
           }
         },
         "p-locate": {
           "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "p-limit": "2.1.0"
+            "p-limit": "^2.0.0"
           }
         },
         "p-try": {
@@ -5439,28 +5487,28 @@
           "version": "1.1.0",
           "bundled": true,
           "requires": {
-            "cyclist": "0.2.2",
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.6"
+            "cyclist": "~0.2.2",
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.1.5"
           }
         },
         "parse-asn1": {
           "version": "5.1.3",
           "bundled": true,
           "requires": {
-            "asn1.js": "4.10.1",
-            "browserify-aes": "1.2.0",
-            "create-hash": "1.2.0",
-            "evp_bytestokey": "1.0.3",
-            "pbkdf2": "3.0.17",
-            "safe-buffer": "5.1.2"
+            "asn1.js": "^4.0.0",
+            "browserify-aes": "^1.0.0",
+            "create-hash": "^1.1.0",
+            "evp_bytestokey": "^1.0.0",
+            "pbkdf2": "^3.0.3",
+            "safe-buffer": "^5.1.1"
           }
         },
         "parse-json": {
           "version": "2.2.0",
           "bundled": true,
           "requires": {
-            "error-ex": "1.3.2"
+            "error-ex": "^1.2.0"
           }
         },
         "parse-passwd": {
@@ -5483,7 +5531,7 @@
           "version": "2.1.0",
           "bundled": true,
           "requires": {
-            "pinkie-promise": "2.0.1"
+            "pinkie-promise": "^2.0.0"
           }
         },
         "path-is-absolute": {
@@ -5502,20 +5550,20 @@
           "version": "1.1.0",
           "bundled": true,
           "requires": {
-            "graceful-fs": "4.1.15",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
+            "graceful-fs": "^4.1.2",
+            "pify": "^2.0.0",
+            "pinkie-promise": "^2.0.0"
           }
         },
         "pbkdf2": {
           "version": "3.0.17",
           "bundled": true,
           "requires": {
-            "create-hash": "1.2.0",
-            "create-hmac": "1.1.7",
-            "ripemd160": "2.0.2",
-            "safe-buffer": "5.1.2",
-            "sha.js": "2.4.11"
+            "create-hash": "^1.1.2",
+            "create-hmac": "^1.1.4",
+            "ripemd160": "^2.0.1",
+            "safe-buffer": "^5.0.1",
+            "sha.js": "^2.4.8"
           }
         },
         "pify": {
@@ -5530,21 +5578,21 @@
           "version": "2.0.1",
           "bundled": true,
           "requires": {
-            "pinkie": "2.0.4"
+            "pinkie": "^2.0.0"
           }
         },
         "pkg-dir": {
           "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "find-up": "3.0.0"
+            "find-up": "^3.0.0"
           },
           "dependencies": {
             "find-up": {
               "version": "3.0.0",
               "bundled": true,
               "requires": {
-                "locate-path": "3.0.0"
+                "locate-path": "^3.0.0"
               }
             }
           }
@@ -5573,37 +5621,37 @@
           "version": "4.0.3",
           "bundled": true,
           "requires": {
-            "bn.js": "4.11.8",
-            "browserify-rsa": "4.0.1",
-            "create-hash": "1.2.0",
-            "parse-asn1": "5.1.3",
-            "randombytes": "2.0.6",
-            "safe-buffer": "5.1.2"
+            "bn.js": "^4.1.0",
+            "browserify-rsa": "^4.0.0",
+            "create-hash": "^1.1.0",
+            "parse-asn1": "^5.0.0",
+            "randombytes": "^2.0.1",
+            "safe-buffer": "^5.1.2"
           }
         },
         "pump": {
           "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "end-of-stream": "1.4.1",
-            "once": "1.4.0"
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
           }
         },
         "pumpify": {
           "version": "1.5.1",
           "bundled": true,
           "requires": {
-            "duplexify": "3.6.1",
-            "inherits": "2.0.3",
-            "pump": "2.0.1"
+            "duplexify": "^3.6.0",
+            "inherits": "^2.0.3",
+            "pump": "^2.0.0"
           },
           "dependencies": {
             "pump": {
               "version": "2.0.1",
               "bundled": true,
               "requires": {
-                "end-of-stream": "1.4.1",
-                "once": "1.4.0"
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
               }
             }
           }
@@ -5624,25 +5672,25 @@
           "version": "2.0.6",
           "bundled": true,
           "requires": {
-            "safe-buffer": "5.1.2"
+            "safe-buffer": "^5.1.0"
           }
         },
         "randomfill": {
           "version": "1.0.4",
           "bundled": true,
           "requires": {
-            "randombytes": "2.0.6",
-            "safe-buffer": "5.1.2"
+            "randombytes": "^2.0.5",
+            "safe-buffer": "^5.1.0"
           }
         },
         "rc": {
           "version": "1.2.8",
           "bundled": true,
           "requires": {
-            "deep-extend": "0.6.0",
-            "ini": "1.3.5",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
+            "deep-extend": "^0.6.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -5655,39 +5703,39 @@
           "version": "1.1.0",
           "bundled": true,
           "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
+            "load-json-file": "^1.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^1.0.0"
           }
         },
         "read-pkg-up": {
           "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
+            "find-up": "^1.0.0",
+            "read-pkg": "^1.0.0"
           }
         },
         "readable-stream": {
           "version": "2.3.6",
           "bundled": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.2",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "readdirp": {
           "version": "2.2.1",
           "bundled": true,
           "requires": {
-            "graceful-fs": "4.1.15",
-            "micromatch": "3.1.10",
-            "readable-stream": "2.3.6"
+            "graceful-fs": "^4.1.11",
+            "micromatch": "^3.1.10",
+            "readable-stream": "^2.0.2"
           }
         },
         "readline": {
@@ -5698,8 +5746,8 @@
           "version": "1.0.2",
           "bundled": true,
           "requires": {
-            "extend-shallow": "3.0.2",
-            "safe-regex": "1.1.0"
+            "extend-shallow": "^3.0.2",
+            "safe-regex": "^1.1.0"
           }
         },
         "remove-trailing-separator": {
@@ -5723,25 +5771,25 @@
           "bundled": true
         },
         "resolve": {
-          "version": "1.9.0",
+          "version": "1.10.0",
           "bundled": true,
           "requires": {
-            "path-parse": "1.0.6"
+            "path-parse": "^1.0.6"
           }
         },
         "resolve-cwd": {
           "version": "2.0.0",
           "bundled": true,
           "requires": {
-            "resolve-from": "3.0.0"
+            "resolve-from": "^3.0.0"
           }
         },
         "resolve-dir": {
           "version": "1.0.1",
           "bundled": true,
           "requires": {
-            "expand-tilde": "2.0.2",
-            "global-modules": "1.0.0"
+            "expand-tilde": "^2.0.0",
+            "global-modules": "^1.0.0"
           }
         },
         "resolve-from": {
@@ -5760,29 +5808,29 @@
           "version": "2.6.3",
           "bundled": true,
           "requires": {
-            "glob": "7.1.3"
+            "glob": "^7.1.3"
           }
         },
         "ripemd160": {
           "version": "2.0.2",
           "bundled": true,
           "requires": {
-            "hash-base": "3.0.4",
-            "inherits": "2.0.3"
+            "hash-base": "^3.0.0",
+            "inherits": "^2.0.1"
           }
         },
         "rtcpeerconnection-shim": {
           "version": "1.2.15",
           "bundled": true,
           "requires": {
-            "sdp": "2.9.0"
+            "sdp": "^2.6.0"
           }
         },
         "run-queue": {
           "version": "1.0.3",
           "bundled": true,
           "requires": {
-            "aproba": "1.2.0"
+            "aproba": "^1.1.1"
           }
         },
         "safe-buffer": {
@@ -5793,7 +5841,7 @@
           "version": "1.1.0",
           "bundled": true,
           "requires": {
-            "ret": "0.1.15"
+            "ret": "~0.1.10"
           }
         },
         "safer-buffer": {
@@ -5805,11 +5853,12 @@
           "bundled": true
         },
         "schema-utils": {
-          "version": "0.4.7",
+          "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "ajv": "6.7.0",
-            "ajv-keywords": "3.2.0"
+            "ajv": "^6.1.0",
+            "ajv-errors": "^1.0.0",
+            "ajv-keywords": "^3.1.0"
           }
         },
         "sdp": {
@@ -5832,17 +5881,17 @@
           "version": "2.0.0",
           "bundled": true,
           "requires": {
-            "extend-shallow": "2.0.1",
-            "is-extendable": "0.1.1",
-            "is-plain-object": "2.0.4",
-            "split-string": "3.1.0"
+            "extend-shallow": "^2.0.1",
+            "is-extendable": "^0.1.1",
+            "is-plain-object": "^2.0.3",
+            "split-string": "^3.0.1"
           },
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
               "bundled": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -5855,15 +5904,15 @@
           "version": "2.4.11",
           "bundled": true,
           "requires": {
-            "inherits": "2.0.3",
-            "safe-buffer": "5.1.2"
+            "inherits": "^2.0.1",
+            "safe-buffer": "^5.0.1"
           }
         },
         "shebang-command": {
           "version": "1.2.0",
           "bundled": true,
           "requires": {
-            "shebang-regex": "1.0.0"
+            "shebang-regex": "^1.0.0"
           }
         },
         "shebang-regex": {
@@ -5878,28 +5927,28 @@
           "version": "0.8.2",
           "bundled": true,
           "requires": {
-            "base": "0.11.2",
-            "debug": "2.6.9",
-            "define-property": "0.2.5",
-            "extend-shallow": "2.0.1",
-            "map-cache": "0.2.2",
-            "source-map": "0.5.7",
-            "source-map-resolve": "0.5.2",
-            "use": "3.1.1"
+            "base": "^0.11.1",
+            "debug": "^2.2.0",
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "map-cache": "^0.2.2",
+            "source-map": "^0.5.6",
+            "source-map-resolve": "^0.5.0",
+            "use": "^3.1.0"
           },
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
               "bundled": true,
               "requires": {
-                "is-descriptor": "0.1.6"
+                "is-descriptor": "^0.1.0"
               }
             },
             "extend-shallow": {
               "version": "2.0.1",
               "bundled": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -5908,39 +5957,39 @@
           "version": "2.1.1",
           "bundled": true,
           "requires": {
-            "define-property": "1.0.0",
-            "isobject": "3.0.1",
-            "snapdragon-util": "3.0.1"
+            "define-property": "^1.0.0",
+            "isobject": "^3.0.0",
+            "snapdragon-util": "^3.0.1"
           },
           "dependencies": {
             "define-property": {
               "version": "1.0.0",
               "bundled": true,
               "requires": {
-                "is-descriptor": "1.0.2"
+                "is-descriptor": "^1.0.0"
               }
             },
             "is-accessor-descriptor": {
               "version": "1.0.0",
               "bundled": true,
               "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.0"
               }
             },
             "is-data-descriptor": {
               "version": "1.0.0",
               "bundled": true,
               "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.0"
               }
             },
             "is-descriptor": {
               "version": "1.0.2",
               "bundled": true,
               "requires": {
-                "is-accessor-descriptor": "1.0.0",
-                "is-data-descriptor": "1.0.0",
-                "kind-of": "6.0.2"
+                "is-accessor-descriptor": "^1.0.0",
+                "is-data-descriptor": "^1.0.0",
+                "kind-of": "^6.0.2"
               }
             }
           }
@@ -5949,14 +5998,14 @@
           "version": "3.0.1",
           "bundled": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.2.0"
           },
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
               "bundled": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -5973,19 +6022,19 @@
           "version": "0.5.2",
           "bundled": true,
           "requires": {
-            "atob": "2.1.2",
-            "decode-uri-component": "0.2.0",
-            "resolve-url": "0.2.1",
-            "source-map-url": "0.4.0",
-            "urix": "0.1.0"
+            "atob": "^2.1.1",
+            "decode-uri-component": "^0.2.0",
+            "resolve-url": "^0.2.1",
+            "source-map-url": "^0.4.0",
+            "urix": "^0.1.0"
           }
         },
         "source-map-support": {
           "version": "0.5.10",
           "bundled": true,
           "requires": {
-            "buffer-from": "1.1.1",
-            "source-map": "0.6.1"
+            "buffer-from": "^1.0.0",
+            "source-map": "^0.6.0"
           },
           "dependencies": {
             "source-map": {
@@ -6002,8 +6051,8 @@
           "version": "3.1.0",
           "bundled": true,
           "requires": {
-            "spdx-expression-parse": "3.0.0",
-            "spdx-license-ids": "3.0.3"
+            "spdx-expression-parse": "^3.0.0",
+            "spdx-license-ids": "^3.0.0"
           }
         },
         "spdx-exceptions": {
@@ -6014,8 +6063,8 @@
           "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "spdx-exceptions": "2.2.0",
-            "spdx-license-ids": "3.0.3"
+            "spdx-exceptions": "^2.1.0",
+            "spdx-license-ids": "^3.0.0"
           }
         },
         "spdx-license-ids": {
@@ -6026,7 +6075,7 @@
           "version": "3.1.0",
           "bundled": true,
           "requires": {
-            "extend-shallow": "3.0.2"
+            "extend-shallow": "^3.0.0"
           }
         },
         "sprintf-js": {
@@ -6037,51 +6086,51 @@
           "version": "6.0.1",
           "bundled": true,
           "requires": {
-            "figgy-pudding": "3.5.1"
+            "figgy-pudding": "^3.5.1"
           }
         },
         "static-extend": {
           "version": "0.1.2",
           "bundled": true,
           "requires": {
-            "define-property": "0.2.5",
-            "object-copy": "0.1.0"
+            "define-property": "^0.2.5",
+            "object-copy": "^0.1.0"
           },
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
               "bundled": true,
               "requires": {
-                "is-descriptor": "0.1.6"
+                "is-descriptor": "^0.1.0"
               }
             }
           }
         },
         "stream-browserify": {
-          "version": "2.0.1",
+          "version": "2.0.2",
           "bundled": true,
           "requires": {
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.6"
+            "inherits": "~2.0.1",
+            "readable-stream": "^2.0.2"
           }
         },
         "stream-each": {
           "version": "1.2.3",
           "bundled": true,
           "requires": {
-            "end-of-stream": "1.4.1",
-            "stream-shift": "1.0.0"
+            "end-of-stream": "^1.1.0",
+            "stream-shift": "^1.0.0"
           }
         },
         "stream-http": {
           "version": "2.8.3",
           "bundled": true,
           "requires": {
-            "builtin-status-codes": "3.0.0",
-            "inherits": "2.0.3",
-            "readable-stream": "2.3.6",
-            "to-arraybuffer": "1.0.1",
-            "xtend": "4.0.1"
+            "builtin-status-codes": "^3.0.0",
+            "inherits": "^2.0.1",
+            "readable-stream": "^2.3.6",
+            "to-arraybuffer": "^1.0.0",
+            "xtend": "^4.0.0"
           }
         },
         "stream-shift": {
@@ -6092,30 +6141,30 @@
           "version": "1.0.2",
           "bundled": true,
           "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
           }
         },
         "string_decoder": {
           "version": "1.1.1",
           "bundled": true,
           "requires": {
-            "safe-buffer": "5.1.2"
+            "safe-buffer": "~5.1.0"
           }
         },
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
           "requires": {
-            "ansi-regex": "2.1.1"
+            "ansi-regex": "^2.0.0"
           }
         },
         "strip-bom": {
           "version": "2.0.0",
           "bundled": true,
           "requires": {
-            "is-utf8": "0.2.1"
+            "is-utf8": "^0.2.0"
           }
         },
         "strip-eof": {
@@ -6130,19 +6179,16 @@
           "version": "0.9.15",
           "bundled": true,
           "requires": {
-            "backo2": "1.0.2",
-            "eventemitter3": "3.1.0",
-            "iterall": "1.2.2",
-            "symbol-observable": "1.2.0",
-            "ws": "5.2.2"
+            "backo2": "^1.0.2",
+            "eventemitter3": "^3.1.0",
+            "iterall": "^1.2.1",
+            "symbol-observable": "^1.0.4",
+            "ws": "^5.2.0"
           }
         },
         "supports-color": {
-          "version": "5.5.0",
-          "bundled": true,
-          "requires": {
-            "has-flag": "3.0.0"
-          }
+          "version": "2.0.0",
+          "bundled": true
         },
         "symbol-observable": {
           "version": "1.2.0",
@@ -6156,22 +6202,22 @@
           "version": "4.4.8",
           "bundled": true,
           "requires": {
-            "chownr": "1.1.1",
-            "fs-minipass": "1.2.5",
-            "minipass": "2.3.5",
-            "minizlib": "1.2.1",
-            "mkdirp": "0.5.1",
-            "safe-buffer": "5.1.2",
-            "yallist": "3.0.3"
+            "chownr": "^1.1.1",
+            "fs-minipass": "^1.2.5",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
+            "mkdirp": "^0.5.0",
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.2"
           }
         },
         "terser": {
-          "version": "3.14.1",
+          "version": "3.16.1",
           "bundled": true,
           "requires": {
-            "commander": "2.17.1",
-            "source-map": "0.6.1",
-            "source-map-support": "0.5.10"
+            "commander": "~2.17.1",
+            "source-map": "~0.6.1",
+            "source-map-support": "~0.5.9"
           },
           "dependencies": {
             "commander": {
@@ -6185,28 +6231,19 @@
           }
         },
         "terser-webpack-plugin": {
-          "version": "1.2.1",
+          "version": "1.2.2",
           "bundled": true,
           "requires": {
-            "cacache": "11.3.2",
-            "find-cache-dir": "2.0.0",
-            "schema-utils": "1.0.0",
-            "serialize-javascript": "1.6.1",
-            "source-map": "0.6.1",
-            "terser": "3.14.1",
-            "webpack-sources": "1.3.0",
-            "worker-farm": "1.6.0"
+            "cacache": "^11.0.2",
+            "find-cache-dir": "^2.0.0",
+            "schema-utils": "^1.0.0",
+            "serialize-javascript": "^1.4.0",
+            "source-map": "^0.6.1",
+            "terser": "^3.16.1",
+            "webpack-sources": "^1.1.0",
+            "worker-farm": "^1.5.2"
           },
           "dependencies": {
-            "schema-utils": {
-              "version": "1.0.0",
-              "bundled": true,
-              "requires": {
-                "ajv": "6.7.0",
-                "ajv-errors": "1.0.1",
-                "ajv-keywords": "3.2.0"
-              }
-            },
             "source-map": {
               "version": "0.6.1",
               "bundled": true
@@ -6217,15 +6254,15 @@
           "version": "2.0.5",
           "bundled": true,
           "requires": {
-            "readable-stream": "2.3.6",
-            "xtend": "4.0.1"
+            "readable-stream": "~2.3.6",
+            "xtend": "~4.0.1"
           }
         },
         "timers-browserify": {
           "version": "2.0.10",
           "bundled": true,
           "requires": {
-            "setimmediate": "1.0.5"
+            "setimmediate": "^1.0.4"
           }
         },
         "to-arraybuffer": {
@@ -6236,14 +6273,14 @@
           "version": "0.3.0",
           "bundled": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
               "bundled": true,
               "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -6252,18 +6289,18 @@
           "version": "3.0.2",
           "bundled": true,
           "requires": {
-            "define-property": "2.0.2",
-            "extend-shallow": "3.0.2",
-            "regex-not": "1.0.2",
-            "safe-regex": "1.1.0"
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "regex-not": "^1.0.2",
+            "safe-regex": "^1.1.0"
           }
         },
         "to-regex-range": {
           "version": "2.1.1",
           "bundled": true,
           "requires": {
-            "is-number": "3.0.0",
-            "repeat-string": "1.6.1"
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
           }
         },
         "tslib": {
@@ -6274,29 +6311,29 @@
           "version": "5.12.1",
           "bundled": true,
           "requires": {
-            "babel-code-frame": "6.26.0",
-            "builtin-modules": "1.1.1",
-            "chalk": "2.4.2",
-            "commander": "2.19.0",
-            "diff": "3.5.0",
-            "glob": "7.1.3",
-            "js-yaml": "3.12.1",
-            "minimatch": "3.0.4",
-            "resolve": "1.9.0",
-            "semver": "5.6.0",
-            "tslib": "1.9.3",
-            "tsutils": "2.29.0"
+            "babel-code-frame": "^6.22.0",
+            "builtin-modules": "^1.1.1",
+            "chalk": "^2.3.0",
+            "commander": "^2.12.1",
+            "diff": "^3.2.0",
+            "glob": "^7.1.1",
+            "js-yaml": "^3.7.0",
+            "minimatch": "^3.0.4",
+            "resolve": "^1.3.2",
+            "semver": "^5.3.0",
+            "tslib": "^1.8.0",
+            "tsutils": "^2.27.2"
           }
         },
         "tslint-config-prettier": {
-          "version": "1.17.0",
+          "version": "1.18.0",
           "bundled": true
         },
         "tsutils": {
           "version": "2.29.0",
           "bundled": true,
           "requires": {
-            "tslib": "1.9.3"
+            "tslib": "^1.8.1"
           }
         },
         "tty-browserify": {
@@ -6308,34 +6345,34 @@
           "bundled": true
         },
         "typescript": {
-          "version": "3.2.4",
+          "version": "3.3.3",
           "bundled": true
         },
         "union-value": {
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "arr-union": "3.1.0",
-            "get-value": "2.0.6",
-            "is-extendable": "0.1.1",
-            "set-value": "0.4.3"
+            "arr-union": "^3.1.0",
+            "get-value": "^2.0.6",
+            "is-extendable": "^0.1.1",
+            "set-value": "^0.4.3"
           },
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
               "bundled": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             },
             "set-value": {
               "version": "0.4.3",
               "bundled": true,
               "requires": {
-                "extend-shallow": "2.0.1",
-                "is-extendable": "0.1.1",
-                "is-plain-object": "2.0.4",
-                "to-object-path": "0.3.0"
+                "extend-shallow": "^2.0.1",
+                "is-extendable": "^0.1.1",
+                "is-plain-object": "^2.0.1",
+                "to-object-path": "^0.3.0"
               }
             }
           }
@@ -6344,31 +6381,31 @@
           "version": "1.1.1",
           "bundled": true,
           "requires": {
-            "unique-slug": "2.0.1"
+            "unique-slug": "^2.0.0"
           }
         },
         "unique-slug": {
           "version": "2.0.1",
           "bundled": true,
           "requires": {
-            "imurmurhash": "0.1.4"
+            "imurmurhash": "^0.1.4"
           }
         },
         "unset-value": {
           "version": "1.0.0",
           "bundled": true,
           "requires": {
-            "has-value": "0.3.1",
-            "isobject": "3.0.1"
+            "has-value": "^0.3.1",
+            "isobject": "^3.0.0"
           },
           "dependencies": {
             "has-value": {
               "version": "0.3.1",
               "bundled": true,
               "requires": {
-                "get-value": "2.0.6",
-                "has-values": "0.1.4",
-                "isobject": "2.1.0"
+                "get-value": "^2.0.3",
+                "has-values": "^0.1.4",
+                "isobject": "^2.0.0"
               },
               "dependencies": {
                 "isobject": {
@@ -6394,7 +6431,7 @@
           "version": "4.2.2",
           "bundled": true,
           "requires": {
-            "punycode": "2.1.1"
+            "punycode": "^2.1.0"
           }
         },
         "urix": {
@@ -6442,8 +6479,8 @@
           "version": "3.0.4",
           "bundled": true,
           "requires": {
-            "spdx-correct": "3.1.0",
-            "spdx-expression-parse": "3.0.0"
+            "spdx-correct": "^3.0.0",
+            "spdx-expression-parse": "^3.0.0"
           }
         },
         "vm-browserify": {
@@ -6457,58 +6494,56 @@
           "version": "1.6.0",
           "bundled": true,
           "requires": {
-            "chokidar": "2.0.4",
-            "graceful-fs": "4.1.15",
-            "neo-async": "2.6.0"
+            "chokidar": "^2.0.2",
+            "graceful-fs": "^4.1.2",
+            "neo-async": "^2.5.0"
           }
         },
         "webpack": {
-          "version": "4.28.4",
+          "version": "4.29.3",
           "bundled": true,
           "requires": {
             "@webassemblyjs/ast": "1.7.11",
             "@webassemblyjs/helper-module-context": "1.7.11",
             "@webassemblyjs/wasm-edit": "1.7.11",
             "@webassemblyjs/wasm-parser": "1.7.11",
-            "acorn": "5.7.3",
-            "acorn-dynamic-import": "3.0.0",
-            "ajv": "6.7.0",
-            "ajv-keywords": "3.2.0",
-            "chrome-trace-event": "1.0.0",
-            "enhanced-resolve": "4.1.0",
-            "eslint-scope": "4.0.0",
-            "json-parse-better-errors": "1.0.2",
-            "loader-runner": "2.4.0",
-            "loader-utils": "1.2.3",
-            "memory-fs": "0.4.1",
-            "micromatch": "3.1.10",
-            "mkdirp": "0.5.1",
-            "neo-async": "2.6.0",
-            "node-libs-browser": "2.2.0",
-            "schema-utils": "0.4.7",
-            "tapable": "1.1.1",
-            "terser-webpack-plugin": "1.2.1",
-            "watchpack": "1.6.0",
-            "webpack-sources": "1.3.0"
+            "acorn": "^6.0.5",
+            "acorn-dynamic-import": "^4.0.0",
+            "ajv": "^6.1.0",
+            "ajv-keywords": "^3.1.0",
+            "chrome-trace-event": "^1.0.0",
+            "enhanced-resolve": "^4.1.0",
+            "eslint-scope": "^4.0.0",
+            "json-parse-better-errors": "^1.0.2",
+            "loader-runner": "^2.3.0",
+            "loader-utils": "^1.1.0",
+            "memory-fs": "~0.4.1",
+            "micromatch": "^3.1.8",
+            "mkdirp": "~0.5.0",
+            "neo-async": "^2.5.0",
+            "node-libs-browser": "^2.0.0",
+            "schema-utils": "^1.0.0",
+            "tapable": "^1.1.0",
+            "terser-webpack-plugin": "^1.1.0",
+            "watchpack": "^1.5.0",
+            "webpack-sources": "^1.3.0"
           }
         },
         "webpack-cli": {
-          "version": "3.2.1",
+          "version": "3.2.3",
           "bundled": true,
           "requires": {
-            "chalk": "2.4.2",
-            "cross-spawn": "6.0.5",
-            "enhanced-resolve": "4.1.0",
-            "findup-sync": "2.0.0",
-            "global-modules": "1.0.0",
-            "global-modules-path": "2.3.1",
-            "import-local": "2.0.0",
-            "interpret": "1.2.0",
-            "lightercollective": "0.1.0",
-            "loader-utils": "1.2.3",
-            "supports-color": "5.5.0",
-            "v8-compile-cache": "2.0.2",
-            "yargs": "12.0.5"
+            "chalk": "^2.4.1",
+            "cross-spawn": "^6.0.5",
+            "enhanced-resolve": "^4.1.0",
+            "findup-sync": "^2.0.0",
+            "global-modules": "^1.0.0",
+            "import-local": "^2.0.0",
+            "interpret": "^1.1.0",
+            "loader-utils": "^1.1.0",
+            "supports-color": "^5.5.0",
+            "v8-compile-cache": "^2.0.2",
+            "yargs": "^12.0.4"
           },
           "dependencies": {
             "ansi-regex": {
@@ -6523,16 +6558,16 @@
               "version": "4.1.0",
               "bundled": true,
               "requires": {
-                "string-width": "2.1.1",
-                "strip-ansi": "4.0.0",
-                "wrap-ansi": "2.1.0"
+                "string-width": "^2.1.1",
+                "strip-ansi": "^4.0.0",
+                "wrap-ansi": "^2.0.0"
               }
             },
             "find-up": {
               "version": "3.0.0",
               "bundled": true,
               "requires": {
-                "locate-path": "3.0.0"
+                "locate-path": "^3.0.0"
               }
             },
             "invert-kv": {
@@ -6547,31 +6582,38 @@
               "version": "2.0.0",
               "bundled": true,
               "requires": {
-                "invert-kv": "2.0.0"
+                "invert-kv": "^2.0.0"
               }
             },
             "os-locale": {
               "version": "3.1.0",
               "bundled": true,
               "requires": {
-                "execa": "1.0.0",
-                "lcid": "2.0.0",
-                "mem": "4.0.0"
+                "execa": "^1.0.0",
+                "lcid": "^2.0.0",
+                "mem": "^4.0.0"
               }
             },
             "string-width": {
               "version": "2.1.1",
               "bundled": true,
               "requires": {
-                "is-fullwidth-code-point": "2.0.0",
-                "strip-ansi": "4.0.0"
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
               }
             },
             "strip-ansi": {
               "version": "4.0.0",
               "bundled": true,
               "requires": {
-                "ansi-regex": "3.0.0"
+                "ansi-regex": "^3.0.0"
+              }
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "bundled": true,
+              "requires": {
+                "has-flag": "^3.0.0"
               }
             },
             "which-module": {
@@ -6582,26 +6624,26 @@
               "version": "12.0.5",
               "bundled": true,
               "requires": {
-                "cliui": "4.1.0",
-                "decamelize": "1.2.0",
-                "find-up": "3.0.0",
-                "get-caller-file": "1.0.3",
-                "os-locale": "3.1.0",
-                "require-directory": "2.1.1",
-                "require-main-filename": "1.0.1",
-                "set-blocking": "2.0.0",
-                "string-width": "2.1.1",
-                "which-module": "2.0.0",
-                "y18n": "3.2.1",
-                "yargs-parser": "11.1.1"
+                "cliui": "^4.0.0",
+                "decamelize": "^1.2.0",
+                "find-up": "^3.0.0",
+                "get-caller-file": "^1.0.1",
+                "os-locale": "^3.0.0",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^1.0.1",
+                "set-blocking": "^2.0.0",
+                "string-width": "^2.0.0",
+                "which-module": "^2.0.0",
+                "y18n": "^3.2.1 || ^4.0.0",
+                "yargs-parser": "^11.1.1"
               }
             },
             "yargs-parser": {
               "version": "11.1.1",
               "bundled": true,
               "requires": {
-                "camelcase": "5.0.0",
-                "decamelize": "1.2.0"
+                "camelcase": "^5.0.0",
+                "decamelize": "^1.2.0"
               }
             }
           }
@@ -6610,8 +6652,8 @@
           "version": "1.3.0",
           "bundled": true,
           "requires": {
-            "source-list-map": "2.0.1",
-            "source-map": "0.6.1"
+            "source-list-map": "^2.0.0",
+            "source-map": "~0.6.1"
           },
           "dependencies": {
             "source-map": {
@@ -6621,11 +6663,11 @@
           }
         },
         "webrtc-adapter": {
-          "version": "7.1.1",
+          "version": "7.2.0",
           "bundled": true,
           "requires": {
-            "rtcpeerconnection-shim": "1.2.15",
-            "sdp": "2.9.0"
+            "rtcpeerconnection-shim": "^1.2.15",
+            "sdp": "^2.9.0"
           }
         },
         "whatwg-fetch": {
@@ -6636,7 +6678,7 @@
           "version": "1.3.1",
           "bundled": true,
           "requires": {
-            "isexe": "2.0.0"
+            "isexe": "^2.0.0"
           }
         },
         "which-module": {
@@ -6647,22 +6689,22 @@
           "version": "1.1.3",
           "bundled": true,
           "requires": {
-            "string-width": "1.0.2"
+            "string-width": "^1.0.2 || 2"
           }
         },
         "worker-farm": {
           "version": "1.6.0",
           "bundled": true,
           "requires": {
-            "errno": "0.1.7"
+            "errno": "~0.1.7"
           }
         },
         "wrap-ansi": {
           "version": "2.1.0",
           "bundled": true,
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
           }
         },
         "wrappy": {
@@ -6670,19 +6712,20 @@
           "bundled": true
         },
         "wrtc": {
-          "version": "0.3.4",
+          "version": "0.3.5",
           "bundled": true,
           "requires": {
-            "nan": "2.12.1",
+            "canvas": "^2.3.0",
+            "nan": "^2.3.2",
             "node-cmake": "2.3.2",
-            "node-pre-gyp": "0.11.0"
+            "node-pre-gyp": "0.11.x"
           }
         },
         "ws": {
           "version": "5.2.2",
           "bundled": true,
           "requires": {
-            "async-limiter": "1.0.0"
+            "async-limiter": "~1.0.0"
           }
         },
         "xtend": {
@@ -6701,59 +6744,179 @@
           "version": "7.1.0",
           "bundled": true,
           "requires": {
-            "camelcase": "3.0.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.3",
-            "os-locale": "1.4.0",
-            "read-pkg-up": "1.0.1",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "1.0.2",
-            "which-module": "1.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "5.0.0"
+            "camelcase": "^3.0.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^1.4.0",
+            "read-pkg-up": "^1.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^1.0.2",
+            "which-module": "^1.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^5.0.0"
           }
         },
         "yargs-parser": {
           "version": "5.0.0",
           "bundled": true,
           "requires": {
-            "camelcase": "3.0.0"
+            "camelcase": "^3.0.0"
           }
         },
         "zen-observable": {
-          "version": "0.8.11",
+          "version": "0.8.13",
           "bundled": true
         },
         "zen-observable-ts": {
-          "version": "0.8.13",
+          "version": "0.8.15",
           "bundled": true,
           "requires": {
-            "zen-observable": "0.8.11"
+            "zen-observable": "^0.8.0"
           }
         }
       }
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "es6-promise": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.6.tgz",
+      "integrity": "sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q=="
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "requires": {
+        "es6-promise": "^4.0.3"
+      }
+    },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+    },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "fast-text-encoding": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.0.tgz",
+      "integrity": "sha512-R9bHCvweUxxwkDwhjav5vxpFvdPGlVngtqmx4pIZfSUhM/Q4NiIUHB456BAf+Q1Nwu3HEZYONtu+Rya+af4jiQ=="
     },
     "fibers": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/fibers/-/fibers-3.1.1.tgz",
       "integrity": "sha512-dl3Ukt08rHVQfY8xGD0ODwyjwrRALtaghuqGH2jByYX1wpY+nAnRQjJ6Dbqq0DnVgNVQ9yibObzbF4IlPyiwPw==",
       "requires": {
-        "detect-libc": "1.0.3"
+        "detect-libc": "^1.0.3"
       }
+    },
+    "fraction.js": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.0.0.tgz",
+      "integrity": "sha1-c5dOL4tR73CVNtYkzJB4Liu2EnQ="
     },
     "gauge": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
       "integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
       "requires": {
-        "ansi": "0.3.1",
-        "has-unicode": "2.0.1",
-        "lodash.pad": "4.5.1",
-        "lodash.padend": "4.6.1",
-        "lodash.padstart": "4.6.1"
+        "ansi": "^0.3.0",
+        "has-unicode": "^2.0.0",
+        "lodash.pad": "^4.1.0",
+        "lodash.padend": "^4.1.0",
+        "lodash.padstart": "^4.1.0"
+      }
+    },
+    "gaxios": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-1.8.2.tgz",
+      "integrity": "sha512-Mp6zmABg+0CxJA4b7DEWQ4ZWQzEaWxRNmHAcvCO+HU3dfoFTY925bdpZrTkLWPEtKjS9RBJKrJInzb+VtvAVYA==",
+      "requires": {
+        "abort-controller": "^2.0.2",
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^2.2.1",
+        "node-fetch": "^2.3.0"
+      }
+    },
+    "gcp-metadata": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-0.9.3.tgz",
+      "integrity": "sha512-caV4S84xAjENtpezLCT/GILEAF5h/bC4cNqZFmt/tjTn8t+JBtTkQrgBrJu3857YdsnlM8rxX/PMcKGtE8hUlw==",
+      "requires": {
+        "gaxios": "^1.0.2",
+        "json-bigint": "^0.3.0"
+      }
+    },
+    "google-auth-library": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-3.1.0.tgz",
+      "integrity": "sha512-EntjrOgSffw5EhZGoV8+ROPwEK/aQpoMZaULw3bKailEGdjaUI25PmmFc4AN6vG/Q24YEUiuLxtTXa1Usar5Eg==",
+      "requires": {
+        "base64-js": "^1.3.0",
+        "fast-text-encoding": "^1.0.0",
+        "gaxios": "^1.2.1",
+        "gcp-metadata": "^0.9.3",
+        "gtoken": "^2.3.2",
+        "https-proxy-agent": "^2.2.1",
+        "jws": "^3.1.5",
+        "lru-cache": "^5.0.0",
+        "semver": "^5.5.0"
+      }
+    },
+    "google-p12-pem": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-1.0.3.tgz",
+      "integrity": "sha512-KGnAiMMWaJp4j4tYVvAjfP3wCKZRLv9M1Nir2wRRNWUYO7j1aX8O9Qgz+a8/EQ5rAvuo4SIu79n6SIdkNl7Msg==",
+      "requires": {
+        "node-forge": "^0.7.5",
+        "pify": "^4.0.0"
+      }
+    },
+    "googleapis": {
+      "version": "37.2.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-37.2.0.tgz",
+      "integrity": "sha512-UenlZ0c4eaVAylIPvvsIlL/q5/3Xg8DuKug5aqdmRMk+tTVfJUmEKgp3s4ZSUOI5oKqO/+arIW5UnY2S62B13w==",
+      "requires": {
+        "google-auth-library": "^3.0.0",
+        "googleapis-common": "^0.7.0"
+      }
+    },
+    "googleapis-common": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-0.7.2.tgz",
+      "integrity": "sha512-9DEJIiO4nS7nw0VE1YVkEfXEj8x8MxsuB+yZIpOBULFSN9OIKcUU8UuKgSZFU4lJmRioMfngktrbkMwWJcUhQg==",
+      "requires": {
+        "gaxios": "^1.2.2",
+        "google-auth-library": "^3.0.0",
+        "pify": "^4.0.0",
+        "qs": "^6.5.2",
+        "url-template": "^2.0.8",
+        "uuid": "^3.2.1"
+      }
+    },
+    "gtoken": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-2.3.2.tgz",
+      "integrity": "sha512-F8EObUGyC8Qd3WXTloNULZBwfUsOABoHElihB1F6zGhT/cy38iPL09wGLRY712I+hQnOyA+sYlgPFX2cOKz0qg==",
+      "requires": {
+        "gaxios": "^1.0.4",
+        "google-p12-pem": "^1.0.0",
+        "jws": "^3.1.5",
+        "mime": "^2.2.0",
+        "pify": "^4.0.0"
       }
     },
     "has-unicode": {
@@ -6761,13 +6924,22 @@
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
     },
+    "https-proxy-agent": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
+      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+      "requires": {
+        "agent-base": "^4.1.0",
+        "debug": "^3.1.0"
+      }
+    },
     "i2c-bus": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/i2c-bus/-/i2c-bus-1.2.5.tgz",
       "integrity": "sha512-cwa0p/wg2bNx7IaCWT1aTK3Aptq3Ul2nTHHHwj8+ACfmPXsbWet5Werkzja80ZlC5sRkhIr/C0zKMmr5wJ8Z/w==",
       "requires": {
-        "bindings": "1.3.1",
-        "nan": "2.8.0"
+        "bindings": "~1.3.0",
+        "nan": "~2.8.0"
       }
     },
     "inherits": {
@@ -6779,6 +6951,33 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "json-bigint": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-0.3.0.tgz",
+      "integrity": "sha1-DM2RLEuCcNBfBW+9E4FLU9OCWx4=",
+      "requires": {
+        "bignumber.js": "^7.0.0"
+      }
+    },
+    "jwa": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.0.tgz",
+      "integrity": "sha512-mt6IHaq0ZZWDBspg0Pheu3r9sVNMEZn+GJe1zcdYyhFcDSclp3J8xEdO4PjZolZ2i8xlaVU1LetHM0nJejYsEw==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.1.tgz",
+      "integrity": "sha512-bGA2omSrFUkd72dhh05bIAN832znP4wOU3lfuXtRBuGTbsmNmDXMQg28f0Vsxaxgk4myF5YkKQpz6qeRpMgX9g==",
+      "requires": {
+        "jwa": "^1.2.0",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "lodash.pad": {
       "version": "4.5.1",
@@ -6795,62 +6994,63 @@
       "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
       "integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs="
     },
+    "lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "requires": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "mathjs": {
+      "version": "3.10.3",
+      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-3.10.3.tgz",
+      "integrity": "sha1-vWV3qOfuIuzjc4OKmeiAj6iNmQ8=",
+      "requires": {
+        "complex.js": "2.0.1",
+        "decimal.js": "7.1.1",
+        "fraction.js": "4.0.0",
+        "seed-random": "2.2.0",
+        "tiny-emitter": "1.0.2",
+        "typed-function": "0.10.5"
+      }
+    },
+    "mime": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.0.tgz",
+      "integrity": "sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w=="
+    },
+    "ms": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+    },
     "nan": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
       "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo="
+    },
+    "node-fetch": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
+      "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA=="
+    },
+    "node-forge": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.6.tgz",
+      "integrity": "sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw=="
     },
     "node-grovepi": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/node-grovepi/-/node-grovepi-2.2.2.tgz",
       "integrity": "sha512-ojsStxBKhTvpfBzXfVC/iJUGUFpOn2yWJ2Akm0VGXTPse0xf+hU1qQAkQhDOzoCWhZLQcR7Kz56zf7KfBOXssg==",
       "requires": {
-        "async": "1.5.2",
-        "buffertools": "2.1.6",
-        "i2c-bus": "1.2.5",
-        "mathjs": "3.10.3",
-        "npmlog": "2.0.4",
-        "sleep": "3.0.1"
-      },
-      "dependencies": {
-        "complex.js": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.0.1.tgz",
-          "integrity": "sha1-6pDHoFrs6vOjdtLA9qeEIXJ9aHk="
-        },
-        "decimal.js": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-7.1.1.tgz",
-          "integrity": "sha1-GtytfXDXqRxCbXVvHrZWbDvmy88="
-        },
-        "fraction.js": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.0.0.tgz",
-          "integrity": "sha1-c5dOL4tR73CVNtYkzJB4Liu2EnQ="
-        },
-        "mathjs": {
-          "version": "3.10.3",
-          "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-3.10.3.tgz",
-          "integrity": "sha1-vWV3qOfuIuzjc4OKmeiAj6iNmQ8=",
-          "requires": {
-            "complex.js": "2.0.1",
-            "decimal.js": "7.1.1",
-            "fraction.js": "4.0.0",
-            "seed-random": "2.2.0",
-            "tiny-emitter": "1.0.2",
-            "typed-function": "0.10.5"
-          }
-        },
-        "tiny-emitter": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-1.0.2.tgz",
-          "integrity": "sha1-jklHDT9V+J4kchA2imu5+1GqFgE="
-        },
-        "typed-function": {
-          "version": "0.10.5",
-          "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-0.10.5.tgz",
-          "integrity": "sha1-Lg8Yq9BlIZ+raUpEamXG0ZgYMsA="
-        }
+        "async": "1.*",
+        "buffertools": "2.1.*",
+        "i2c-bus": "1.*",
+        "mathjs": "3.10.*",
+        "npmlog": "2.*",
+        "sleep": "3.*"
       }
     },
     "npmlog": {
@@ -6858,28 +7058,38 @@
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-2.0.4.tgz",
       "integrity": "sha1-mLUlMPJRTKkNCexbIsiEZyI3VpI=",
       "requires": {
-        "ansi": "0.3.1",
-        "are-we-there-yet": "1.1.5",
-        "gauge": "1.2.7"
+        "ansi": "~0.3.1",
+        "are-we-there-yet": "~1.1.2",
+        "gauge": "~1.2.5"
       }
+    },
+    "pify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
     },
     "process-nextick-args": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
     },
+    "qs": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.6.0.tgz",
+      "integrity": "sha512-KIJqT9jQJDQx5h5uAVPimw6yVg2SekOKu959OCtktD3FjzbpvaPr8i4zzg07DOMz+igA4W/aNM7OV8H37pFYfA=="
+    },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "2.0.0",
-        "safe-buffer": "5.1.2",
-        "string_decoder": "1.1.1",
-        "util-deprecate": "1.0.2"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "safe-buffer": {
@@ -6892,12 +7102,17 @@
       "resolved": "https://registry.npmjs.org/seed-random/-/seed-random-2.2.0.tgz",
       "integrity": "sha1-KpsZ4lCoFwmSMaW5mk2vgLf77VQ="
     },
+    "semver": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+    },
     "sleep": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/sleep/-/sleep-3.0.1.tgz",
       "integrity": "sha1-vk0XxXk2DgfgTtgXK6KxCmkFTfM=",
       "requires": {
-        "nan": "2.8.0"
+        "nan": ">=2.0.0"
       }
     },
     "string_decoder": {
@@ -6905,14 +7120,29 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "~5.1.0"
       }
     },
+    "tiny-emitter": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-1.0.2.tgz",
+      "integrity": "sha1-jklHDT9V+J4kchA2imu5+1GqFgE="
+    },
     "tslint-config-prettier": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/tslint-config-prettier/-/tslint-config-prettier-1.17.0.tgz",
-      "integrity": "sha512-NKWNkThwqE4Snn4Cm6SZB7lV5RMDDFsBwz6fWUkTxOKGjMx8ycOHnjIbhn7dZd5XmssW3CwqUjlANR6EhP9YQw==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/tslint-config-prettier/-/tslint-config-prettier-1.18.0.tgz",
+      "integrity": "sha512-xPw9PgNPLG3iKRxmK7DWr+Ea/SzrvfHtjFt5LBl61gk2UBG/DB9kCXRjv+xyIU1rUtnayLeMUVJBcMX8Z17nDg==",
       "dev": true
+    },
+    "typed-function": {
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-0.10.5.tgz",
+      "integrity": "sha1-Lg8Yq9BlIZ+raUpEamXG0ZgYMsA="
+    },
+    "url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE="
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -6923,6 +7153,11 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
       "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+    },
+    "yallist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+      "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
   "dependencies": {
     "dss-client": "file:../dss/client",
     "fibers": "^3.1.1",
+    "googleapis": "^37.2.0",
+    "googleapis-common": "^0.7.2",
     "node-grovepi": "^2.2.2",
     "uuid": "^3.3.2"
   }


### PR DESCRIPTION
This change refactors the way that module initialization works. Rather than the previous static initializers that look like this:

`export function initialize() { ... }`

which required us to modify the user code to run the initializers for all modules that were used. Instead, we now declare initializers when the modules are imported using

```
onInit(() => {
    ...
});
```

This allows us to run the user code with zero modifications. It also allows TypeScript to perform some extra optimizations (for example: imports can be optimized out if no imported items are _actually_ used), so we can add default modules in PXT that will not be imported unless they are actually used.

Additionally, a companion Exit handler has been introduced:

```
onExit(() => {
   ...
});
```

This allows modules to free resources such as allocated GPIO pins, USB devices, etc. if/when the program terminates. These exit handlers will be run when the program calls `process.exit()`, exits normally from a `SIGTERM`, throws an uncaught exception, or receives an interrupt (`SIGINT`). It will not run if the process is killed for any uncatchable reason (such as `SIGKILL`).