### PR TITLE
Refactored logging support.

### DIFF
--- a/examples/test_await.ts
+++ b/examples/test_await.ts
@@ -12,6 +12,6 @@ function somePromiseFunction() {
 }
 
 Fiber(() => {
-    console.log("The first message!");
-    console.log(_core._await(somePromiseFunction()));
+    console.info("The first message!");
+    console.info(_core._await(somePromiseFunction()));
 }).run()

--- a/examples/test_create_sheet.ts
+++ b/examples/test_create_sheet.ts
@@ -10,5 +10,5 @@ _core.main(() => {
     const cell = sheet.readCell("A1");
 
     // tslint:disable-next-line:no-console
-    console.log(cell);
+    console.info(cell);
 });

--- a/examples/test_get_sheet.ts
+++ b/examples/test_get_sheet.ts
@@ -11,5 +11,5 @@ _core.main(() => {
     const cell = sheet.readCell("A1");
 
     // tslint:disable-next-line:no-console
-    console.log(cell);
+    console.info(cell);
 });

--- a/examples/test_loglevels.ts
+++ b/examples/test_loglevels.ts
@@ -1,0 +1,12 @@
+import * as _core from '../lib/core-exec';
+import * as console from '../lib/console';
+
+_core.main(() => {
+    console.error("Log level is error.");
+    console.warn("Log level is warn.");
+    console.info("Log level is info.");
+    console.verbose("Log level is verbose.");
+    console.debug("Log level is debug.");
+
+    console.info("Runtime base is: ", _core.RUNTIME_BASE);
+});

--- a/examples/test_recv.ts
+++ b/examples/test_recv.ts
@@ -4,9 +4,9 @@ import * as netsimple from '../lib/netsimple';
 
 _core.main(() => {
     netsimple.start();
-    console.log(netsimple.getId());
+    console.info("ID", netsimple.getId());
     netsimple.onReceiveString((peer: string, message: string) => {
-        console.log("Got data: " + message + " from " + peer);
+        console.info("Got data: " + message + " from " + peer);
         netsimple.sendString(message, peer);
     })
 });

--- a/examples/test_send.ts
+++ b/examples/test_send.ts
@@ -6,11 +6,11 @@ import * as netsimple from '../lib/netsimple';
 _core.main(() => {
     netsimple.start();
     loops.forever(() => {
-        console.log("Message every 2");
+        console.info("Message every 2");
         loops.pause(2000);
     });
     loops.forever(() => {
-        console.log("Message every 5");
+        console.info("Message every 5");
         loops.pause(5000);
     });
 

--- a/lib/console.ts
+++ b/lib/console.ts
@@ -1,5 +1,133 @@
-const _CONSOLE = console;
+import { RUNTIME_BASE } from "./core-exec";
 
-export function log(...args: any[]) {
-    _CONSOLE.log(...args);
+type LogLevel = "silent" | "error" | "warn" | "info" | "verbose" | "debug";
+
+enum TermSettings {
+    Reset = "\x1b[0m",
+    Bright = "\x1b[1m",
+    Dim = "\x1b[2m",
+    Underscore = "\x1b[4m",
+    Blink = "\x1b[5m",
+    Reverse = "\x1b[7m",
+    Hidden = "\x1b[8m",
+
+    FgBlack = "\x1b[30m",
+    FgRed = "\x1b[31m",
+    FgGreen = "\x1b[32m",
+    FgYellow = "\x1b[33m",
+    FgBlue = "\x1b[34m",
+    FgMagenta = "\x1b[35m",
+    FgCyan = "\x1b[36m",
+    FgWhite = "\x1b[37m",
+
+    BgBlack = "\x1b[40m",
+    BgRed = "\x1b[41m",
+    BgGreen = "\x1b[42m",
+    BgYellow = "\x1b[43m",
+    BgBlue = "\x1b[44m",
+    BgMagenta = "\x1b[45m",
+    BgCyan = "\x1b[46m",
+    BgWhite = "\x1b[47m",
+}
+
+const _DEFAULT_CONSOLE: Console = console;
+const _DEFAULT_LEVEL: LogLevel = "info"
+
+const _PRECEDENCE: LogLevel[] = ["silent", "error", "warn", "info", "verbose", "debug"];
+
+let _level: LogLevel = (() => {
+    if (process.env.LOG_LEVEL && (_PRECEDENCE as string[]).includes(process.env.LOG_LEVEL)) {
+        return (process.env.LOG_LEVEL as LogLevel);
+    } else {
+        return _DEFAULT_LEVEL;
+    }
+})();
+
+let _console: Console = _DEFAULT_CONSOLE;
+
+let _active_levels: Set<LogLevel> = _get_active_levels();
+
+function _get_active_levels(): Set<LogLevel> {
+    return new Set(_PRECEDENCE.slice(0, _PRECEDENCE.indexOf(_level) + 1));
+}
+
+function _get_caller_info(): string {
+    const stack = new Error().stack;
+    return stack.split('\n')[4].split("at ")[1].trim().split(RUNTIME_BASE)[1];
+}
+
+function _timestamp() : string {
+    return TermSettings.FgGreen + "[" + (new Date()).toISOString() + "]" + TermSettings.Reset;
+}
+
+function _colorize(v: string, color: TermSettings) : string {
+    return color + v + TermSettings.Reset;
+}
+
+function _header(v: LogLevel) : string{
+    let color : TermSettings;
+    switch (v) {
+        case "error":
+            color = TermSettings.FgRed;
+            break;
+        case "warn":
+            color = TermSettings.FgYellow;
+            break;
+        case "info":
+            color = TermSettings.FgWhite;
+            break;
+        case "verbose":
+            color = TermSettings.FgCyan;
+            break;
+        case "debug":
+            color = TermSettings.FgMagenta;
+            break;
+        default:
+            throw new Error("Tried to log with an invalid log-level or 'silent'");
+    }
+
+    return `${_timestamp()} ${_colorize(v.toUpperCase(), color)} (${_get_caller_info()})\t:: `
+}
+
+export function getLogLevel(): LogLevel {
+    return _level;
+}
+
+export function setLogLevel(level: LogLevel): void {
+    _level = level;
+    _active_levels = _get_active_levels();
+}
+
+export function replaceConsole(newConsole: Console): void {
+    _console = newConsole;
+}
+
+export function error(...args: any[]) {
+    if (_active_levels.has("error")) {
+        _console.error(_header('error'), ...args);
+    }
+}
+
+export function warn(...args: any[]) {
+    if (_active_levels.has("warn")) {
+        _console.error(_header('warn'), ...args);
+    }
+}
+
+export function info(...args: any[]) {
+    if (_active_levels.has("info")) {
+        _console.log(_header('info'), ...args);
+    }
+}
+
+export function verbose(...args: any[]) {
+    if (_active_levels.has("verbose")) {
+        _console.log(_header('verbose'), ...args);
+    }
+}
+
+export function debug(...args: any[]) {
+    if (_active_levels.has("debug")) {
+        _console.log(_header('debug'), ...args);
+    }
 }

--- a/lib/core-exec.ts
+++ b/lib/core-exec.ts
@@ -1,6 +1,10 @@
+import 'source-map-support/register';
+
 import Fiber = require('fibers');
 import Future = require('fibers/future');
-import { log } from './console';
+import { error, info } from './console';
+
+export const RUNTIME_BASE : string = __filename.split('/').slice(0, -3).join('/') + '/';
 
 export const env = process.env;
 
@@ -20,7 +24,7 @@ const exitHandlers: Set<() => void> = new Set();
  *  Log the reason and kill the process.
  */
 function catchPromiseRejection(reason: any) {
-	log("Unhandled exception from Event Loop:", reason);
+	error("Unhandled exception from Event Loop:", reason);
 	process.exit(1);
 }
 
@@ -30,6 +34,8 @@ function catchPromiseRejection(reason: any) {
  * @param body The main thread of the program.
  */
 export function main(body: () => void) {
+	info("Starting... ");
+
 	if (!executing) {
 		executing = true;
 		initializers.forEach((init) => init());
@@ -79,15 +85,20 @@ export function _await<T>(task: Promise<T>, catcher?: (reason: any) => PromiseLi
 
 // Set up the exit handlers for the module
 function atexit(reason: string, ...args: any[]) {
-	log("EXIT: " + reason);
-
 	if (reason === 'uncaughtException') {
-		log(args[0].message, args[0].stack);
+		error(args[0].message, args[0].stack);
 	}
 
 	exitHandlers.forEach((h) => h());
+
+	process.exit(1);
 }
 
 process.on('exit', () => atexit('EXIT'));
 process.on('SIGINT', () => atexit('SIGINT'));
 process.on('uncaughtException', (e) => atexit('uncaughtException', e));
+
+
+onExit(() => {
+	info("Exiting...");
+})

--- a/lib/netsimple.ts
+++ b/lib/netsimple.ts
@@ -4,7 +4,7 @@ import uuidv4 = require('uuid/v4');
 
 import { _await, _detach, env, hacks, onExit } from './core-exec';
 
-import { log } from './console';
+import { info } from './console';
 
 let client: SignalingClient;
 
@@ -83,7 +83,7 @@ function _join(id?: string) {
         client.on('CONN_OPEN', (args) => {
             const channel: RTCDataChannel = args[1];
             const otherID = args[2]
-            log("Connection opened with: " + otherID);
+            info("Connection opened with: " + otherID);
             connections[otherID] = channel;
             wireConnEvents(channel, otherID);
         });

--- a/lib/sheets.ts
+++ b/lib/sheets.ts
@@ -4,9 +4,8 @@ import { env, onInit } from "./core-exec";
 import { google } from 'googleapis';
 import { OAuth2Client } from "googleapis-common";
 
-import { log } from './console';
-
 import { _await } from './core-exec';
+import { info } from "./console";
 
 
 let token: any;
@@ -77,7 +76,7 @@ export class Spreadsheet {
                     // Handle error.
                     reject(err);
                 } else {
-                    log(`${result.data} cells cleared.`)
+                    info(`${result.data} cells cleared.`)
                     resolve();
                 }
             });
@@ -153,7 +152,7 @@ export class Spreadsheet {
                     // Handle error.
                     reject(err);
                 } else {
-                    log(`${result.data.updates.updatedCells} cells appended.`)
+                    info(`${result.data.updates.updatedCells} cells appended.`)
                     resolve();
                 }
             });
@@ -181,7 +180,7 @@ export function createSheet(title: string): Spreadsheet {
                 // Handle error.
                 reject(err);
             } else {
-                log(spreadsheet.data.spreadsheetId)
+                info(spreadsheet.data.spreadsheetId)
                 newID = spreadsheet.data.spreadsheetId;
                 resolve(new Spreadsheet(newID, title));
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,6 +89,11 @@
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
+    "buffer-from": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+    },
     "buffertools": {
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/buffertools/-/buffertools-2.1.6.tgz",
@@ -7171,6 +7176,20 @@
       "integrity": "sha1-vk0XxXk2DgfgTtgXK6KxCmkFTfM=",
       "requires": {
         "nan": ">=2.0.0"
+      }
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+    },
+    "source-map-support": {
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.11.tgz",
+      "integrity": "sha512-//sajEx/fGL3iw6fltKMdPvy8kL3kJ2O3iuYlRoT3k9Kb4BjOoZ+BZzaNHeuaruSt+Kf3Zk9tnfAQg9/AJqUVQ==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "string_decoder": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "googleapis-common": "^0.7.2",
     "node-grovepi": "^2.2.2",
     "onoff": "^3.2.2",
+    "source-map-support": "^0.5.11",
     "uuid": "^3.3.2"
   }
 }


### PR DESCRIPTION
This makes a few major changes to support for logging in the runtime. Logs are now much prettier using terminal colors, they have timestamps & stack information, and they support a number of different error levels. The levels are:

- silent
- error
- warn
- info
- verbose
- debug

The error level is set using the LOG_LEVEL environment variable, otherwise the default level of `info` is used. There are corresponding functions for each level (other than `silent`) in the `console` package, and each function will produce output if the configured log level is at least (according to the order above) as high as the function. For example, if a log level of `warn` is set, then `console.error()` and `console.warn()` will produce output, but the other functions will not. This allows us to print more debug output without cluttering the logs and log files live.

Signed-off-by: William Temple <William.Temple@colorado.edu>